### PR TITLE
Fix: Add install tutorial in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,19 @@
 
 ## Usage
 
-1. Clone this repository locally
-2. Open the app's settings
-3. Select `import theme` and browse to where you cloned Catppuccin
-4. Select it
+1. Clone this repository into the extentions folder of VSCode/VSCodium:
+	
+`{version}` = `.vscode` for VSCode or `.vscode-oss`for VSCodium.
+
+* On **Mac**: `$HOME/{version}/extensions`
+* On **Windows**: `%USERPROFILE%\{version}\extensions`
+ 
+2. Open the app
+3. type:
+* **Mac**: CMD+SHIFT+p
+* **Windows**: CTRL+SHIFT+p
+4. Select the catppuccin theme
+5. Enjoy! :sparkles:
 
 ## Preview
 <p align="center">


### PR DESCRIPTION
I saw the readme was still missing a specified Usage section, so I added that 😄 

These will probably get outdated once the theme is uploaded to the marketplace but for now it could possible help some people out. Like in #5