### PR TITLE
fix: improve readability by switching active and inactive tab bg color

### DIFF
--- a/themes/Catppuccin-color-theme.json
+++ b/themes/Catppuccin-color-theme.json
@@ -48,17 +48,17 @@
         {
             "name": "All conditionals",
             "scope": [
-				"keyword.control",
+                "keyword.control",
                 "keyword.control.for",
                 "keyword.control.while",
                 "keyword.control.if",
                 "keyword.control.else",
                 "keyword.control.switch",
                 "keyword.control.case"
-			],
+            ],
             "settings": {
                 "foreground": "#ddb6f2",
-				"fontStyle": "bold"
+                "fontStyle": "bold"
             }
         },
         {
@@ -510,7 +510,7 @@
             ],
             "settings": {
                 "foreground": "#ddb6f2",
-				"fontStyle": "bold"
+                "fontStyle": "bold"
             }
         },
         {
@@ -608,7 +608,7 @@
         {
             "name": "C++ constructor/destructor",
             "scope": [
-                "entity.name.function.definition.special.constructor", 
+                "entity.name.function.definition.special.constructor",
                 "entity.name.function.definition.special.member.destructor"
             ],
             "settings": {
@@ -2459,10 +2459,10 @@
         "editorGroupHeader.tabsBackground": "#1e1e2e",
         "tab.activeForeground": "#d9e0ee",
         "tab.border": "#302d41",
-        "tab.activeBackground": "#302d41",
+        "tab.activeBackground": "#1e1e2e",
         "tab.activeBorder": "#00000000",
         "tab.activeBorderTop": "#00000000",
-        "tab.inactiveBackground": "#1e1e2e",
+        "tab.inactiveBackground": "#302d41",
         "tab.inactiveForeground": "#d9e0ee64",
         "scrollbarSlider.background": "#575268",
         "scrollbarSlider.hoverBackground": "#6e6c7e",


### PR DESCRIPTION
Suggestion: improve readability by switching active and inactive tab bg color.

Intuitively, you'd expect the color of the selected tab to match the container below. Especially when two tabs are open. This confused me many times.

**Before**

<img width="811" alt="Screenshot 2022-02-10 at 10 38 20" src="https://user-images.githubusercontent.com/63727247/153379822-97409d11-b67f-4f6c-b483-47f28fa4bb13.png">
 
**After**

<img width="808" alt="Screenshot 2022-02-10 at 10 38 33" src="https://user-images.githubusercontent.com/63727247/153379982-993dcadf-8840-430b-b605-d53a7173e11a.png">
