### PR TITLE
fix: cpp operators

### DIFF
--- a/themes/Catppuccin-color-theme.json
+++ b/themes/Catppuccin-color-theme.json
@@ -33,7 +33,7 @@
             "name": "All parameter",
             "scope": [
                 "variable.parameter.function",
-                "variable.parameter.function-call",
+                "variable.parameter.function-call"
             ],
             "settings": {
                 "foreground": "#f5e0dc",
@@ -953,7 +953,6 @@
             "settings": {
                 "foreground": "#89dceb"
             }
-        },
         },
         {
             "name": "python block",

--- a/themes/Catppuccin-color-theme.json
+++ b/themes/Catppuccin-color-theme.json
@@ -460,9 +460,9 @@
         {
             "name": "C++ directive",
             "scope": [
-                "punctuation.definition.directive",
                 "keyword.control.directive",
-                "keyword.other.using.directive"
+                "keyword.other.using.directive",
+                "punctuation.definition.directive"
             ],
             "settings": {
                 "foreground": "#b5e8e0",
@@ -473,7 +473,11 @@
             "name": "C++ ifdef directive",
             "scope": [
                 "keyword.control.directive.conditional.ifdef.cpp",
-                "keyword.control.directive.endif.cpp"
+                "keyword.control.directive.else.cpp",
+                "keyword.control.directive.else.cpp punctuation.definition.directive.cpp",
+                "keyword.control.directive.endif.cpp",
+                "keyword.control.directive.conditional.ifdef.cpp punctuation.definition.directive.cpp",
+                "keyword.control.directive.endif.cpp punctuation.definition.directive.cpp"
             ],
             "settings": {
                 "foreground": "#f28fad"

--- a/themes/Catppuccin-color-theme.json
+++ b/themes/Catppuccin-color-theme.json
@@ -30,6 +30,17 @@
             }
         },
         {
+            "name": "All parameter",
+            "scope": [
+                "variable.parameter.function",
+                "variable.parameter.function-call",
+            ],
+            "settings": {
+                "foreground": "#f5e0dc",
+                "fontStyle": "italic"
+            }
+        },
+        {
             "name": "All numeric",
             "scope": ["constant.numeric.decimal", "constant.numeric.integer"],
             "settings": {
@@ -590,13 +601,6 @@
             }
         },
         {
-            "name": "Text",
-            "scope": "variable.parameter.function",
-            "settings": {
-                "foreground": "#d9e0ee"
-            }
-        },
-        {
             "name": "Comment Markup Link",
             "scope": "comment markup.link",
             "settings": {
@@ -944,25 +948,12 @@
             }
         },
         {
-            "name": "python parameter",
-            "scope": "variable.parameter.function.language.python",
-            "settings": {
-                "foreground": "#f5e0dc"
-            }
-        },
-        {
             "name": "python type",
             "scope": "support.type.python",
             "settings": {
                 "foreground": "#89dceb"
             }
         },
-        {
-            "name": "pyCs",
-            "scope": "variable.parameter.function.python",
-            "settings": {
-                "foreground": "#fae3b0"
-            }
         },
         {
             "name": "python block",
@@ -1006,20 +997,6 @@
             "scope": "entity.name.namespace",
             "settings": {
                 "foreground": "#f8bd96"
-            }
-        },
-        {
-            "name": "Variables",
-            "scope": "variable",
-            "settings": {
-                "foreground": "#d9e0ee"
-            }
-        },
-        {
-            "name": "Variables",
-            "scope": "variable.c",
-            "settings": {
-                "foreground": "#d9e0ee"
             }
         },
         {

--- a/themes/Catppuccin-color-theme.json
+++ b/themes/Catppuccin-color-theme.json
@@ -537,7 +537,7 @@
                 "punctuation.section.parens.begin.bracket.round.c",
                 "punctuation.section.parens.end.bracket.round.c",
                 "punctuation.section.parameters.begin.bracket.round.c",
-                "punctuation.section.parameters.end.bracket.round.c",
+                "punctuation.section.parameters.end.bracket.round.c"
             ],
             "settings": {
                 "foreground": "#d9e0ee"
@@ -547,7 +547,7 @@
             "name": "C++ storage type modifier",
             "scope": "storage.type.built-in.primitive.cpp",
             "settings": {
-                "foreground": "#b5e8e0"
+                "foreground": "#fae3b0"
             }
         },
         {

--- a/themes/Catppuccin-color-theme.json
+++ b/themes/Catppuccin-color-theme.json
@@ -1260,7 +1260,7 @@
             "name": "Attribute IDs",
             "scope": "entity.other.attribute-name.id",
             "settings": {
-                "fontStyle": "normal",
+                "fontStyle": "",
                 "foreground": "#96cdfb"
             }
         },
@@ -1268,7 +1268,7 @@
             "name": "Attribute class",
             "scope": "entity.other.attribute-name.class.css",
             "settings": {
-                "fontStyle": "normal",
+                "fontStyle": "",
                 "foreground": "#fae3b0"
             }
         },

--- a/themes/Catppuccin-color-theme.json
+++ b/themes/Catppuccin-color-theme.json
@@ -446,8 +446,31 @@
                 "foreground": "#b5e8e0"
             }
         },
+
         {
-            "name": "C++ *def keywords",
+            "name": "C++ constructor/destructor",
+            "scope": [
+                "entity.name.function.definition.special.constructor",
+                "entity.name.function.definition.special.member.destructor"
+            ],
+            "settings": {
+                "foreground": "#c9cbff"
+            }
+        },
+        {
+            "name": "C++ directive",
+            "scope": [
+                "punctuation.definition.directive",
+                "keyword.control.directive",
+                "keyword.other.using.directive"
+            ],
+            "settings": {
+                "foreground": "#b5e8e0",
+                "fontStyle": "italic"
+            }
+        },
+        {
+            "name": "C++ ifdef directive",
             "scope": [
                 "keyword.control.directive.conditional.ifdef.cpp",
                 "keyword.control.directive.endif.cpp"
@@ -499,7 +522,41 @@
                 "foreground": "#f5c2e7"
             }
         },
-
+        {
+            "name": "C++ block",
+            "scope": [
+                "punctuation.section.block.begin.bracket.curly.cpp",
+                "punctuation.section.block.end.bracket.curly.cpp",
+                "punctuation.terminator.statement.c",
+                "punctuation.section.block.begin.bracket.curly.c",
+                "punctuation.section.block.end.bracket.curly.c",
+                "punctuation.section.parens.begin.bracket.round.c",
+                "punctuation.section.parens.end.bracket.round.c",
+                "punctuation.section.parameters.begin.bracket.round.c",
+                "punctuation.section.parameters.end.bracket.round.c",
+            ],
+            "settings": {
+                "foreground": "#d9e0ee"
+            }
+        },
+        {
+            "name": "C++ storage type modifier",
+            "scope": "storage.type.built-in.primitive.cpp",
+            "settings": {
+                "foreground": "#b5e8e0"
+            }
+        },
+        {
+            "name": "C++/C#",
+            "scope": [
+                "entity.name.label.cs",
+                "entity.name.scope-resolution.function.call",
+                "entity.name.scope-resolution.function.definition"
+            ],
+            "settings": {
+                "foreground": "#f8bd96"
+            }
+        },
         {
             "name": "support.constant.edge",
             "scope": "support.constant.edge",
@@ -568,90 +625,6 @@
             "scope": "markup.deleted.diff",
             "settings": {
                 "foreground": "#b5e8e0"
-            }
-        },
-        {
-            "name": "C++ directives",
-            "scope": [
-                "punctuation.definition.directive",
-                "keyword.control.directive",
-                "keyword.other.using.directive"
-            ],
-            "settings": {
-                "foreground": "#b5e8e0",
-                "fontStyle": "italic"
-            }
-        },
-        {
-            "name": "C++ function",
-            "scope": "meta.function.c,meta.function.cpp",
-            "settings": {
-                "foreground": "#b5e8e0"
-            }
-        },
-        {
-            "name": "C++ constructor/destructor",
-            "scope": [
-                "entity.name.function.definition.special.constructor",
-                "entity.name.function.definition.special.member.destructor"
-            ],
-            "settings": {
-                "foreground": "#c9cbff"
-            }
-        },
-        {
-            "name": "C++ block",
-            "scope": [
-                "punctuation.section.block.begin.bracket.curly.cpp",
-                "punctuation.section.block.end.bracket.curly.cpp",
-                "punctuation.terminator.statement.c",
-                "punctuation.section.block.begin.bracket.curly.c",
-                "punctuation.section.block.end.bracket.curly.c",
-                "punctuation.section.parens.begin.bracket.round.c",
-                "punctuation.section.parens.end.bracket.round.c",
-                "punctuation.section.parameters.begin.bracket.round.c",
-                "punctuation.section.parameters.end.bracket.round.c",
-            ],
-            "settings": {
-                "foreground": "#d9e0ee"
-            }
-        },
-        {
-            "name": "C++ storage type modifier",
-            "scope": "storage.type.built-in.primitive.cpp",
-            "settings": {
-                "foreground": "#b5e8e0"
-            }
-        },
-        {
-            "name": "C++ pointer/reference",
-            "scope": [
-                "storage.modifier.pointer.cpp",
-                "storage.modifier.reference.cpp"
-            ],
-            "settings": {
-                "foreground": "#b5e8e0"
-            }
-        },
-        {
-            "name": "C++ loop/conditional",
-            "scope": [
-                "keyword.control.for",
-                "keyword.control.while",
-                "keyword.control.if",
-                "keyword.control.else",
-                "keyword.control.switch",
-                "keyword.control.case"
-            ],
-            "settings": {
-                "foreground": "#ddb6f2"
-            }
-        },
-        {
-            "name": "C++ return",
-            "scope": "keyword.control.return",
-            "settings": {
-                "foreground": "#f5c2e7"
             }
         },
         {
@@ -2169,17 +2142,6 @@
             "scope": ["punctuation.definition.tag.xi"],
             "settings": {
                 "foreground": "#6e6c7e"
-            }
-        },
-        {
-            "name": "C++/C#",
-            "scope": [
-                "entity.name.label.cs",
-                "entity.name.scope-resolution.function.call",
-                "entity.name.scope-resolution.function.definition"
-            ],
-            "settings": {
-                "foreground": "#f8bd96"
             }
         },
         {

--- a/themes/Catppuccin-color-theme.json
+++ b/themes/Catppuccin-color-theme.json
@@ -18,8 +18,7 @@
             "name": "All variable",
             "scope": ["variable.language", "variable.other"],
             "settings": {
-                "foreground": "#d9e0ee",
-                "fontStyle": "italic"
+                "foreground": "#d9e0ee"
             }
         },
         {
@@ -64,12 +63,9 @@
         {
             "name": "All punctuation brackets",
             "scope": [
-                "punctuation.brackets.curly",
-                "punctuation.brackets.round",
-                "punctuation.brackets.square",
-                "punctuation.brackets.attribute",
-                "punctuation.definition.parameters.end",
-                "punctuation.definition.parameters.begin"
+                "punctuation.brackets",
+                "punctuation.section",
+                "punctuation.definition"
             ],
             "settings": {
                 "foreground": "#988ba2"
@@ -93,7 +89,7 @@
             "name": "All operators",
             "scope": [
                 "keyword.operator.comparison",
-                "keyword.operator.assignment.equal",
+                "keyword.operator.assignment",
                 "keyword.operator.arrow.skinny",
                 "keyword.operator.math",
                 "keyword.operator.key-value",
@@ -425,10 +421,7 @@
 
         {
             "name": "C++ Puct Delimeters",
-            "scope": [
-                "keyword.control.directive",
-                "punctuation.terminator.statement.cpp"
-            ],
+            "scope": "punctuation.terminator.statement.cpp",
             "settings": {
                 "foreground": "#b5e8e0",
                 "fontStyle": "bold"
@@ -472,20 +465,6 @@
             "settings": {
                 "foreground": "#f5e0dc",
                 "fontStyle": "italic"
-            }
-        },
-        {
-            "name": "C++ block",
-            "scope": "punctuation.section.block.begin.bracket.curly.cpp,punctuation.section.block.end.bracket.curly.cpp,punctuation.terminator.statement.c,punctuation.section.block.begin.bracket.curly.c,punctuation.section.block.end.bracket.curly.c,punctuation.section.parens.begin.bracket.round.c,punctuation.section.parens.end.bracket.round.c,punctuation.section.parameters.begin.bracket.round.c,punctuation.section.parameters.end.bracket.round.c",
-            "settings": {
-                "foreground": "#d9e0ee"
-            }
-        },
-        {
-            "name": "C++ storage type modifier",
-            "scope": "storage.type.built-in.primitive.cpp",
-            "settings": {
-                "foreground": "#b5e8e0"
             }
         },
         {
@@ -592,10 +571,15 @@
             }
         },
         {
-            "name": "C++ preprocessor",
-            "scope": "keyword.control.directive",
+            "name": "C++ directives",
+            "scope": [
+                "punctuation.definition.directive",
+                "keyword.control.directive",
+                "keyword.other.using.directive"
+            ],
             "settings": {
-                "foreground": "#b5e8e0"
+                "foreground": "#b5e8e0",
+                "fontStyle": "italic"
             }
         },
         {
@@ -617,7 +601,17 @@
         },
         {
             "name": "C++ block",
-            "scope": "punctuation.section.block.begin.bracket.curly.cpp,punctuation.section.block.end.bracket.curly.cpp,punctuation.terminator.statement.c,punctuation.section.block.begin.bracket.curly.c,punctuation.section.block.end.bracket.curly.c,punctuation.section.parens.begin.bracket.round.c,punctuation.section.parens.end.bracket.round.c,punctuation.section.parameters.begin.bracket.round.c,punctuation.section.parameters.end.bracket.round.c",
+            "scope": [
+                "punctuation.section.block.begin.bracket.curly.cpp",
+                "punctuation.section.block.end.bracket.curly.cpp",
+                "punctuation.terminator.statement.c",
+                "punctuation.section.block.begin.bracket.curly.c",
+                "punctuation.section.block.end.bracket.curly.c",
+                "punctuation.section.parens.begin.bracket.round.c",
+                "punctuation.section.parens.end.bracket.round.c",
+                "punctuation.section.parameters.begin.bracket.round.c",
+                "punctuation.section.parameters.end.bracket.round.c",
+            ],
             "settings": {
                 "foreground": "#d9e0ee"
             }
@@ -765,7 +759,10 @@
         },
         {
             "name": "operator logical",
-            "scope": "keyword.operator.logical",
+            "scope": [
+                "keyword.operator.logical",
+                "keyword.operator.ternary"
+            ],
             "settings": {
                 "foreground": "#89dceb",
                 "fontStyle": "bold"
@@ -920,20 +917,17 @@
                 "keyword.operator.relational"
             ],
             "settings": {
-                "foreground": "#89dceb"
+                "foreground": "#89dceb",
+                "fontStyle": "bold"
             }
         },
         {
-            "name": "C operator assignment",
+            "name": "C operators",
             "scope": [
-                "keyword.operator.assignment.c",
-                "keyword.operator.comparison.c",
                 "keyword.operator.c",
                 "keyword.operator.increment.c",
                 "keyword.operator.decrement.c",
                 "keyword.operator.bitwise.shift.c",
-                "keyword.operator.assignment.cpp",
-                "keyword.operator.comparison.cpp",
                 "keyword.operator.cpp",
                 "keyword.operator.increment.cpp",
                 "keyword.operator.decrement.cpp",
@@ -1019,21 +1013,8 @@
             "name": "Operators",
             "scope": "keyword.operator",
             "settings": {
-                "foreground": "#d9e0ee"
-            }
-        },
-        {
-            "name": "Compound Assignment Operators",
-            "scope": "keyword.operator.assignment.compound",
-            "settings": {
-                "foreground": "#f28fad"
-            }
-        },
-        {
-            "name": "Compound Assignment Operators js/ts",
-            "scope": "keyword.operator.assignment.compound.js,keyword.operator.assignment.compound.ts",
-            "settings": {
-                "foreground": "#89dceb"
+                "foreground": "#89dceb",
+                "fontStyle": "bold"
             }
         },
         {
@@ -1848,20 +1829,6 @@
             "scope": ["keyword.other.substitution.end"],
             "settings": {
                 "foreground": "#abe9b3"
-            }
-        },
-        {
-            "name": "js operator.assignment",
-            "scope": ["keyword.operator.assignment"],
-            "settings": {
-                "foreground": "#89dceb"
-            }
-        },
-        {
-            "name": "go operator",
-            "scope": ["keyword.operator.assignment.go"],
-            "settings": {
-                "foreground": "#f8bd96"
             }
         },
         {


### PR DESCRIPTION
- Change brackets to maroon
- Change 'using' directive (namespaces) to teal (same as include)
- Change compound assignment and ternary operators to sky to match other logical/assignment operators
- Change variables to not italic since 99% of my files were italic otherwise
- Removed some redundant syntax definitions