### PR TITLE
fix: active line number

### DIFF
--- a/themes/Catppuccin-color-theme.json
+++ b/themes/Catppuccin-color-theme.json
@@ -2305,7 +2305,7 @@
         "editor.wordHighlightBackground": "#575757b8",
         "editor.lineHighlightBackground": "#ffffff0A",
         "editor.lineHighlightBorder": "#1e1e2e",
-        "editorLineNumber.activeForeground": "#c3bac6",
+        "editorLineNumber.activeForeground": "#abe9b3",
         "editorLink.activeForeground": "#96cdfb",
         "editorIndentGuide.background": "#302d41",
         "editorIndentGuide.activeBackground": "#575268",


### PR DESCRIPTION
As pointed out in catppuccin/sublime-text#1, the active line number color in neovim is green. I changed it here accordingly. Not sure if a different color is preferred by others, but imo the difference between gray1 and gray2 wasn't nearly enough.