### PR TITLE
Minimal Port to v0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"displayName": "Catppuccin for VSCode",
 	"publisher": "Catppuccin",
 	"description": "Warm mid-tone dark theme to show off your vibrant self!",
-	"version": "1.0.6",
+	"version": "2.0.0",
 	"engines": {
 		"vscode": "^1.13.0"
 	},
@@ -13,9 +13,24 @@
 	"contributes": {
 		"themes": [
 			{
-				"label": "Catppuccin",
+				"label": "Catppuccin Mocha",
 				"uiTheme": "vs-dark",
-				"path": "./themes/Catppuccin-color-theme.json"
+				"path": "./themes/Catppuccin-mocha-color-theme.json"
+			},
+			{
+				"label": "Catppuccin Macchiato",
+				"uiTheme": "vs-dark",
+				"path": "./themes/Catppuccin-macchiato-color-theme.json"
+			},
+			{
+				"label": "Catppuccin Frappé",
+				"uiTheme": "vs-dark",
+				"path": "./themes/Catppuccin-frappe-color-theme.json"
+			},
+			{
+				"label": "Catppuccin Latte",
+				"uiTheme": "vs",
+				"path": "./themes/Catppuccin-latte-color-theme.json"
 			}
 		]
 	},

--- a/themes/Catppuccin-frappe-color-theme.json
+++ b/themes/Catppuccin-frappe-color-theme.json
@@ -1,0 +1,2469 @@
+{
+    "name": "Catppuccin Frappé",
+    "type": "dark",
+    "semanticHighlighting": true,
+    "semanticTokenColors": {
+        "enumMember": {
+            "foreground": "#99d1db"
+        },
+        "variable.constant": {
+            "foreground": "#e5c890"
+        },
+        "variable.defaultLibrary": {
+            "foreground": "#ef9f76"
+        }
+    },
+    "tokenColors": [
+        {
+            "name": "All variable",
+            "scope": ["variable.language", "variable.other"],
+            "settings": {
+                "foreground": "#eebebe"
+            }
+        },
+        {
+            "name": "All function",
+            "scope": ["entity.name.function", "support.function"],
+            "settings": {
+                "foreground": "#8caaee",
+                "fontStyle": "italic"
+            }
+        },
+        {
+            "name": "All parameter",
+            "scope": [
+                "variable.parameter.function",
+                "variable.parameter.function-call"
+            ],
+            "settings": {
+                "foreground": "#f4b8e4",
+                "fontStyle": "italic"
+            }
+        },
+        {
+            "name": "All numeric",
+            "scope": ["constant.numeric.decimal", "constant.numeric.integer"],
+            "settings": {
+                "foreground": "#ef9f76",
+                "fontStyle": "bold"
+            }
+        },
+        {
+            "name": "All types",
+            "scope": "entity.name.type",
+            "settings": {
+                "foreground": "#8caaee"
+            }
+        },
+        {
+            "name": "All conditionals",
+            "scope": [
+                "keyword.control",
+                "keyword.control.for",
+                "keyword.control.while",
+                "keyword.control.if",
+                "keyword.control.else",
+                "keyword.control.switch",
+                "keyword.control.case"
+            ],
+            "settings": {
+                "foreground": "#e78284",
+                "fontStyle": "bold"
+            }
+        },
+        {
+            "name": "All punctuation brackets",
+            "scope": [
+                "punctuation.brackets",
+                "punctuation.section",
+                "punctuation.definition"
+            ],
+            "settings": {
+                "foreground": "#838ba7"
+            }
+        },
+        {
+            "name": "All punctuation delimeters",
+            "scope": "punctuation.semi",
+            "settings": {
+                "foreground": "#81c8be"
+            }
+        },
+        {
+            "name": "All namespace",
+            "scope": "entity.name.namespace",
+            "settings": {
+                "foreground": "#f2d5cf"
+            }
+        },
+        {
+            "name": "All operators",
+            "scope": [
+                "keyword.operator.comparison",
+                "keyword.operator.assignment",
+                "keyword.operator.arrow.skinny",
+                "keyword.operator.math",
+                "keyword.operator.key-value",
+                "keyword.operator.misc",
+                "keyword.operator.namespace"
+            ],
+            "settings": {
+                "foreground": "#99d1db",
+                "fontStyle": "bold"
+            }
+        },
+        {
+            "name": "All built-in constants",
+            "scope": "constant.language",
+            "settings": {
+                "foreground": "#babbf1",
+                "fontStyle": "italic"
+            }
+        },
+        {
+            "name": "All constants",
+            "scope": "constant.other",
+            "settings": {
+                "foreground": "#ef9f76"
+            }
+        },
+        {
+            "name": "JSON quoted string",
+            "scope": "source.json meta.structure.dictionary.json > string.quoted.json",
+            "settings": {
+                "foreground": "#81c8be"
+            }
+        },
+        {
+            "name": "JSON punctuation string",
+            "scope": "source.json meta.structure.dictionary.json > string.quoted.json > punctuation.string",
+            "settings": {
+                "foreground": "#81c8be"
+            }
+        },
+        {
+            "name": "JSON punct structure",
+            "scope": "source.json meta.structure.dictionary.json > value.json > string.quoted.json,source.json meta.structure.array.json > value.json > string.quoted.json,source.json meta.structure.dictionary.json > value.json > string.quoted.json > punctuation,source.json meta.structure.array.json > value.json > string.quoted.json > punctuation",
+            "settings": {
+                "foreground": "#a6d189"
+            }
+        },
+        {
+            "name": "JSON property name",
+            "scope": "support.type.property-name.json.comments",
+            "settings": {
+                "foreground": "#8caaee"
+            }
+        },
+        {
+            "name": "JSON constants",
+            "scope": "constant.language.json.comments",
+            "settings": {
+                "foreground": "#ef9f76"
+            }
+        },
+        {
+            "name": "JSON punctuation",
+            "scope": [
+                "punctuation.separator.dictionary.pair.json.comments",
+                "punctuation.separator.array.json.comments"
+            ],
+            "settings": {
+                "foreground": "#81c8be"
+            }
+        },
+        {
+            "name": "JSON brackets",
+            "scope": [
+                "punctuation.definition.dictionary.begin.json.comments",
+                "punctuation.definition.dictionary.end.json.comments",
+                "punctuation.definition.array.begin.json.comments",
+                "punctuation.definition.array.end.json.comments"
+            ],
+            "settings": {
+                "foreground": "#949cbb"
+            }
+        },
+        {
+            "name": "JSON constant language",
+            "scope": "source.json meta.structure.dictionary.json > constant.language.json,source.json meta.structure.array.json > constant.language.json",
+            "settings": {
+                "foreground": "#99d1db"
+            }
+        },
+        {
+            "name": "JSON property name [VSCODE-CUSTOM]",
+            "scope": "support.type.property-name.json",
+            "settings": {
+                "foreground": "#81c8be"
+            }
+        },
+        {
+            "name": "[VSCODE-CUSTOM] JSON Punctuation for Property Name",
+            "scope": "support.type.property-name.json punctuation",
+            "settings": {
+                "foreground": "#81c8be"
+            }
+        },
+
+        {
+            "name": "unison punctuation",
+            "scope": "punctuation.definition.delayed.unison,punctuation.definition.list.begin.unison,punctuation.definition.list.end.unison,punctuation.definition.ability.begin.unison,punctuation.definition.ability.end.unison,punctuation.operator.assignment.as.unison,punctuation.separator.pipe.unison,punctuation.separator.delimiter.unison,punctuation.definition.hash.unison",
+            "settings": {
+                "foreground": "#81c8be"
+            }
+        },
+        {
+            "name": "haskell variable generic-type",
+            "scope": "variable.other.generic-type.haskell",
+            "settings": {
+                "foreground": "#e78284"
+            }
+        },
+        {
+            "name": "haskell storage type",
+            "scope": "storage.type.haskell",
+            "settings": {
+                "foreground": "#e5c890"
+            }
+        },
+        {
+            "name": "support.variable.magic.python",
+            "scope": "support.variable.magic.python",
+            "settings": {
+                "foreground": "#c6d0f5"
+            }
+        },
+        {
+            "name": "punctuation.separator.parameters.python",
+            "scope": "punctuation.separator.period.python,punctuation.separator.element.python,punctuation.parenthesis.begin.python,punctuation.parenthesis.end.python",
+            "settings": {
+                "foreground": "#c6d0f5"
+            }
+        },
+        {
+            "name": "variable.parameter.function.language.special.self.python",
+            "scope": "variable.parameter.function.language.special.self.python",
+            "settings": {
+                "foreground": "#ef9f76"
+            }
+        },
+
+        {
+            "name": "Rust modifier",
+            "scope": "storage.modifier.lifetime.rust",
+            "settings": {
+                "foreground": "#c6d0f5"
+            }
+        },
+        {
+            "name": "Rust types",
+            "scope": "entity.name.type.rust",
+            "settings": {
+                "foreground": "#e5c890"
+            }
+        },
+        {
+            "name": "Rust functions std",
+            "scope": "support.function.std.rust",
+            "settings": {
+                "foreground": "#8caaee"
+            }
+        },
+        {
+            "name": "Rust functions",
+            "scope": "entity.name.function.rust",
+            "settings": {
+                "foreground": "#8caaee",
+                "fontStyle": "italic"
+            }
+        },
+        {
+            "name": "Rust function keyword",
+            "scope": "keyword.other.fn.rust",
+            "settings": {
+                "foreground": "#ea999c"
+            }
+        },
+        {
+            "name": "Rust conditionals",
+            "scope": "keyword.control.rust",
+            "settings": {
+                "foreground": "#ca9ee6",
+                "fontStyle": "bold"
+            }
+        },
+        {
+            "name": "Rust punctuation brackets",
+            "scope": [
+                "punctuation.brackets.curly.rust",
+                "punctuation.brackets.round.rust",
+                "punctuation.brackets.square.rust",
+                "punctuation.brackets.attribute.rust"
+            ],
+            "settings": {
+                "foreground": "#838ba7"
+            }
+        },
+        {
+            "name": "Rust namespace",
+            "scope": "entity.name.namespace.rust",
+            "settings": {
+                "foreground": "#f2d5cf"
+            }
+        },
+        {
+            "name": "Rust punctuation delimeters",
+            "scope": "punctuation.semi.rust",
+            "settings": {
+                "foreground": "#81c8be"
+            }
+        },
+        {
+            "name": "Rust operators",
+            "scope": [
+                "keyword.operator.comparison.rust",
+                "keyword.operator.assignment.equal.rust",
+                "keyword.operator.arrow.skinny.rust",
+                "keyword.operator.math.rust",
+                "keyword.operator.key-value.rust",
+                "keyword.operator.misc.rust"
+            ],
+            "settings": {
+                "foreground": "#99d1db"
+            }
+        },
+        {
+            "name": "Rust operator namespaces",
+            "scope": "keyword.operator.namespace.rust",
+            "settings": {
+                "foreground": "#81c8be"
+            }
+        },
+        {
+            "name": "Rust definition attributes",
+            "scope": [
+                "punctuation.definition.attribute.rust",
+                "keyword.operator.attribute.inner.rust"
+            ],
+            "settings": {
+                "foreground": "#81c8be",
+                "fontStyle": "bold"
+            }
+        },
+        {
+            "name": "Rust math logic",
+            "scope": "constant.numeric.decimal.rust",
+            "settings": {
+                "foreground": "#ef9f76"
+            }
+        },
+        {
+            "name": "Rust constants",
+            "scope": "support.constant.core.rust",
+            "settings": {
+                "foreground": "#e5c890"
+            }
+        },
+        {
+            "name": "Rust entity name",
+            "scope": "entity.name.lifetime.rust",
+            "settings": {
+                "foreground": "#ef9f76"
+            }
+        },
+        {
+            "name": "Rust variable",
+            "scope": ["variable.language.rust", "variable.other.rust"],
+            "settings": {
+                "foreground": "#c6d0f5",
+                "fontStyle": "italic"
+            }
+        },
+        {
+            "name": "Rust misc operators",
+            "scope": "keyword.operator.misc.rust",
+            "settings": {
+                "foreground": "#c6d0f5"
+            }
+        },
+        {
+            "name": "Rust sigil operator",
+            "scope": "keyword.operator.sigil.rust",
+            "settings": {
+                "foreground": "#e78284"
+            }
+        },
+
+        {
+            "name": "Lua operators",
+            "scope": "keyword.operator.lua",
+            "settings": {
+                "foreground": "#99d1db",
+                "fontStyle": "bold"
+            }
+        },
+        {
+            "name": "Lua numeric",
+            "scope": "constant.numeric.integer.lua",
+            "settings": {
+                "foreground": "#ef9f76",
+                "fontStyle": "bold"
+            }
+        },
+        {
+            "name": "Lua other vars",
+            "scope": "variable.other.lua",
+            "settings": {
+                "foreground": "#babbf1",
+                "fontStyle": "italic"
+            }
+        },
+        {
+            "name": "Lua brackets",
+            "scope": [
+                "punctuation.definition.parameters.end.lua",
+                "punctuation.definition.parameters.begin.lua"
+            ],
+            "settings": {
+                "foreground": "#838ba7"
+            }
+        },
+
+        {
+            "name": "C++ Puct Delimeters",
+            "scope": "punctuation.terminator.statement.cpp",
+            "settings": {
+                "foreground": "#81c8be",
+                "fontStyle": "bold"
+            }
+        },
+        {
+            "name": "C++ Operators",
+            "scope": [
+                "punctuation.separator.scope-resolution.cpp",
+                "punctuation.separator.scope-resolution.namespace.alias.cpp",
+                "punctuation.separator.scope-resolution.namespace.using.cpp"
+            ],
+            "settings": {
+                "foreground": "#99d1db",
+                "fontStyle": "bold"
+            }
+        },
+        {
+            "name": "C++ function",
+            "scope": "meta.function.c,meta.function.cpp",
+            "settings": {
+                "foreground": "#81c8be"
+            }
+        },
+
+        {
+            "name": "C++ constructor/destructor",
+            "scope": [
+                "entity.name.function.definition.special.constructor",
+                "entity.name.function.definition.special.member.destructor"
+            ],
+            "settings": {
+                "foreground": "#babbf1"
+            }
+        },
+        {
+            "name": "C++ directive",
+            "scope": [
+                "keyword.control.directive",
+                "keyword.other.using.directive",
+                "punctuation.definition.directive"
+            ],
+            "settings": {
+                "foreground": "#81c8be",
+                "fontStyle": "italic"
+            }
+        },
+        {
+            "name": "C++ ifdef directive",
+            "scope": [
+                "keyword.control.directive.conditional.ifdef.cpp",
+                "keyword.control.directive.else.cpp",
+                "keyword.control.directive.else.cpp punctuation.definition.directive.cpp",
+                "keyword.control.directive.endif.cpp",
+                "keyword.control.directive.conditional.ifdef.cpp punctuation.definition.directive.cpp",
+                "keyword.control.directive.endif.cpp punctuation.definition.directive.cpp"
+            ],
+            "settings": {
+                "foreground": "#e78284"
+            }
+        },
+        {
+            "name": "C++ misc",
+            "scope": [
+                "entity.name.other.preprocessor.macro.predefined.probably",
+                "entity.name.scope-resolution.cpp"
+            ],
+            "settings": {
+                "foreground": "#f2d5cf",
+                "fontStyle": "italic"
+            }
+        },
+        {
+            "name": "C++ pointer/reference",
+            "scope": [
+                "storage.modifier.pointer.cpp",
+                "storage.modifier.reference.cpp"
+            ],
+            "settings": {
+                "foreground": "#81c8be"
+            }
+        },
+        {
+            "name": "C++ loop/conditional",
+            "scope": [
+                "keyword.control.for",
+                "keyword.control.while",
+                "keyword.control.if",
+                "keyword.control.else",
+                "keyword.control.switch",
+                "keyword.control.case"
+            ],
+            "settings": {
+                "foreground": "#ca9ee6",
+                "fontStyle": "bold"
+            }
+        },
+        {
+            "name": "C++ return",
+            "scope": "keyword.control.return",
+            "settings": {
+                "foreground": "#f4b8e4"
+            }
+        },
+        {
+            "name": "C++ block",
+            "scope": [
+                "punctuation.section.block.begin.bracket.curly.cpp",
+                "punctuation.section.block.end.bracket.curly.cpp",
+                "punctuation.terminator.statement.c",
+                "punctuation.section.block.begin.bracket.curly.c",
+                "punctuation.section.block.end.bracket.curly.c",
+                "punctuation.section.parens.begin.bracket.round.c",
+                "punctuation.section.parens.end.bracket.round.c",
+                "punctuation.section.parameters.begin.bracket.round.c",
+                "punctuation.section.parameters.end.bracket.round.c"
+            ],
+            "settings": {
+                "foreground": "#c6d0f5"
+            }
+        },
+        {
+            "name": "C++ storage type modifier",
+            "scope": "storage.type.built-in.primitive.cpp",
+            "settings": {
+                "foreground": "#e5c890"
+            }
+        },
+        {
+            "name": "C++/C#",
+            "scope": [
+                "entity.name.label.cs",
+                "entity.name.scope-resolution.function.call",
+                "entity.name.scope-resolution.function.definition"
+            ],
+            "settings": {
+                "foreground": "#ef9f76"
+            }
+        },
+        {
+            "name": "support.constant.edge",
+            "scope": "support.constant.edge",
+            "settings": {
+                "foreground": "#e78284"
+            }
+        },
+        {
+            "name": "regexp constant character-class",
+            "scope": "constant.other.character-class.regexp",
+            "settings": {
+                "foreground": "#81c8be"
+            }
+        },
+        {
+            "name": "regexp operator.quantifier",
+            "scope": "keyword.operator.quantifier.regexp",
+            "settings": {
+                "foreground": "#e5c890"
+            }
+        },
+        {
+            "name": "punctuation.definition",
+            "scope": "punctuation.definition.string.begin,punctuation.definition.string.end",
+            "settings": {
+                "foreground": "#a6d189"
+            }
+        },
+        {
+            "name": "Comment Markup Link",
+            "scope": "comment markup.link",
+            "settings": {
+                "foreground": "#737994"
+            }
+        },
+        {
+            "name": "markup diff",
+            "scope": "markup.changed.diff",
+            "settings": {
+                "foreground": "#ef9f76"
+            }
+        },
+        {
+            "name": "diff",
+            "scope": "meta.diff.header.from-file,meta.diff.header.to-file,punctuation.definition.from-file.diff,punctuation.definition.to-file.diff",
+            "settings": {
+                "foreground": "#8caaee"
+            }
+        },
+        {
+            "name": "inserted.diff",
+            "scope": "markup.inserted.diff",
+            "settings": {
+                "foreground": "#a6d189"
+            }
+        },
+        {
+            "name": "deleted.diff",
+            "scope": "markup.deleted.diff",
+            "settings": {
+                "foreground": "#81c8be"
+            }
+        },
+        {
+            "name": "Quote multi",
+            "scope": [
+                "string.quoted.docstring.multi",
+                "string.quoted.multi",
+                "source.python string.quoted.docstring.multi.python punctuation.definition.string.begin.python",
+                "source.python string.quoted.docstring.multi.python punctuation.definition.string.end.python",
+                "source.python string.quoted.multi.python punctuation.definition.string.begin.python",
+                "source.python string.quoted.multi.python punctuation.definition.string.end.python",
+                "markup.fenced_code.block"
+            ],
+            "settings": {
+                "foreground": "#81c8be",
+                "fontStyle": "italic"
+            }
+        },
+        {
+            "name": "js/ts punctuation separator key-value",
+            "scope": "punctuation.separator.key-value",
+            "settings": {
+                "foreground": "#c6d0f5"
+            }
+        },
+        {
+            "name": "js/ts import keyword",
+            "scope": "keyword.operator.expression.import",
+            "settings": {
+                "foreground": "#8caaee"
+            }
+        },
+        {
+            "name": "math js/ts",
+            "scope": "support.constant.math",
+            "settings": {
+                "foreground": "#ef9f76"
+            }
+        },
+        {
+            "name": "math property js/ts",
+            "scope": "support.constant.property.math",
+            "settings": {
+                "foreground": "#e5c890"
+            }
+        },
+        {
+            "name": "js/ts variable.other.constant",
+            "scope": "variable.other.constant",
+            "settings": {
+                "foreground": "#c6d0f5"
+            }
+        },
+        {
+            "name": "java type",
+            "scope": [
+                "storage.type.annotation.java",
+                "storage.type.object.array.java"
+            ],
+            "settings": {
+                "foreground": "#ef9f76"
+            }
+        },
+        {
+            "name": "java source",
+            "scope": "source.java",
+            "settings": {
+                "foreground": "#81c8be"
+            }
+        },
+        {
+            "name": "java modifier.import",
+            "scope": "punctuation.section.block.begin.java,punctuation.section.block.end.java,punctuation.definition.method-parameters.begin.java,punctuation.definition.method-parameters.end.java,meta.method.identifier.java,punctuation.section.method.begin.java,punctuation.section.method.end.java,punctuation.terminator.java,punctuation.section.class.begin.java,punctuation.section.class.end.java,punctuation.section.inner-class.begin.java,punctuation.section.inner-class.end.java,meta.method-call.java,punctuation.section.class.begin.bracket.curly.java,punctuation.section.class.end.bracket.curly.java,punctuation.section.method.begin.bracket.curly.java,punctuation.section.method.end.bracket.curly.java,punctuation.separator.period.java,punctuation.bracket.angle.java,punctuation.definition.annotation.java,meta.method.body.java",
+            "settings": {
+                "foreground": "#c6d0f5"
+            }
+        },
+        {
+            "name": "java modifier.import",
+            "scope": "meta.method.java",
+            "settings": {
+                "foreground": "#8caaee"
+            }
+        },
+        {
+            "name": "java modifier.import",
+            "scope": "storage.modifier.import.java,storage.type.java,storage.type.generic.java",
+            "settings": {
+                "foreground": "#ef9f76"
+            }
+        },
+        {
+            "name": "java instanceof",
+            "scope": "keyword.operator.instanceof.java",
+            "settings": {
+                "foreground": "#e78284"
+            }
+        },
+        {
+            "name": "java variable.name",
+            "scope": "meta.definition.variable.name.java",
+            "settings": {
+                "foreground": "#c6d0f5"
+            }
+        },
+        {
+            "name": "operator logical",
+            "scope": [
+                "keyword.operator.logical",
+                "keyword.operator.ternary"
+            ],
+            "settings": {
+                "foreground": "#99d1db",
+                "fontStyle": "bold"
+            }
+        },
+        {
+            "name": "operator bitwise",
+            "scope": "keyword.operator.bitwise",
+            "settings": {
+                "foreground": "#99d1db"
+            }
+        },
+        {
+            "name": "operator channel",
+            "scope": "keyword.operator.channel",
+            "settings": {
+                "foreground": "#99d1db"
+            }
+        },
+        {
+            "name": "support.constant.property-value.scss",
+            "scope": "support.constant.property-value.scss,support.constant.property-value.css",
+            "settings": {
+                "foreground": "#e5c890"
+            }
+        },
+        {
+            "name": "CSS/SCSS/LESS Operators",
+            "scope": "keyword.operator.css,keyword.operator.scss,keyword.operator.less",
+            "settings": {
+                "foreground": "#99d1db"
+            }
+        },
+        {
+            "name": "css color standard name",
+            "scope": "support.constant.color.w3c-standard-color-name.css,support.constant.color.w3c-standard-color-name.scss",
+            "settings": {
+                "foreground": "#e5c890"
+            }
+        },
+        {
+            "name": "css comma",
+            "scope": "punctuation.separator.list.comma.css",
+            "settings": {
+                "foreground": "#c6d0f5"
+            }
+        },
+        {
+            "name": "css attribute-name.id",
+            "scope": "support.constant.color.w3c-standard-color-name.css",
+            "settings": {
+                "foreground": "#e5c890"
+            }
+        },
+        {
+            "name": "css property-name",
+            "scope": "support.type.vendored.property-name.css",
+            "settings": {
+                "foreground": "#99d1db"
+            }
+        },
+        {
+            "name": "js/ts module",
+            "scope": "support.module.node,support.type.object.module,support.module.node",
+            "settings": {
+                "foreground": "#ef9f76"
+            }
+        },
+        {
+            "name": "entity.name.type.module",
+            "scope": "entity.name.type.module",
+            "settings": {
+                "foreground": "#ef9f76"
+            }
+        },
+        {
+            "name": "js variable readwrite",
+            "scope": "variable.other.readwrite,meta.object-literal.key,support.variable.property,support.variable.object.process,support.variable.object.node",
+            "settings": {
+                "foreground": "#c6d0f5"
+            }
+        },
+        {
+            "name": "js/ts json",
+            "scope": "support.constant.json",
+            "settings": {
+                "foreground": "#e5c890"
+            }
+        },
+        {
+            "name": "js/ts Keyword",
+            "scope": [
+                "keyword.operator.expression.instanceof",
+                "keyword.operator.new",
+                "keyword.operator.ternary",
+                "keyword.operator.optional",
+                "keyword.operator.expression.keyof"
+            ],
+            "settings": {
+                "foreground": "#e78284"
+            }
+        },
+        {
+            "name": "js/ts console",
+            "scope": "support.type.object.console",
+            "settings": {
+                "foreground": "#81c8be"
+            }
+        },
+        {
+            "name": "js/ts support.variable.property.process",
+            "scope": "support.variable.property.process",
+            "settings": {
+                "foreground": "#e5c890"
+            }
+        },
+        {
+            "name": "js console function",
+            "scope": "entity.name.function,support.function.console",
+            "settings": {
+                "foreground": "#8caaee"
+            }
+        },
+        {
+            "name": "operator",
+            "scope": "keyword.operator.delete",
+            "settings": {
+                "foreground": "#e78284"
+            }
+        },
+        {
+            "name": "js dom",
+            "scope": "support.type.object.dom",
+            "settings": {
+                "foreground": "#99d1db"
+            }
+        },
+        {
+            "name": "js dom variable",
+            "scope": ["support.variable.dom", "support.variable.property.dom"],
+            "settings": {
+                "foreground": "#81c8be"
+            }
+        },
+        {
+            "name": "keyword.operator",
+            "scope": [
+                "keyword.operator.arithmetic",
+                "keyword.operator.comparison",
+                "keyword.operator.decrement",
+                "keyword.operator.increment",
+                "keyword.operator.relational"
+            ],
+            "settings": {
+                "foreground": "#99d1db",
+                "fontStyle": "bold"
+            }
+        },
+        {
+            "name": "C operators",
+            "scope": [
+                "keyword.operator.c",
+                "keyword.operator.increment.c",
+                "keyword.operator.decrement.c",
+                "keyword.operator.bitwise.shift.c",
+                "keyword.operator.cpp",
+                "keyword.operator.increment.cpp",
+                "keyword.operator.decrement.cpp",
+                "keyword.operator.bitwise.shift.cpp"
+            ],
+            "settings": {
+                "foreground": "#99d1db",
+                "fontStyle": "bold"
+            }
+        },
+        {
+            "name": "Punctuation",
+            "scope": "punctuation.separator.delimiter",
+            "settings": {
+                "foreground": "#c6d0f5"
+            }
+        },
+        {
+            "name": "Other punctuation .c",
+            "scope": "punctuation.separator.c,punctuation.separator.cpp",
+            "settings": {
+                "foreground": "#e78284"
+            }
+        },
+        {
+            "name": "C type posix-reserved",
+            "scope": "support.type.posix-reserved.c,support.type.posix-reserved.cpp",
+            "settings": {
+                "foreground": "#99d1db"
+            }
+        },
+        {
+            "name": "keyword.operator.sizeof.c",
+            "scope": "keyword.operator.sizeof.c,keyword.operator.sizeof.cpp",
+            "settings": {
+                "foreground": "#e78284"
+            }
+        },
+        {
+            "name": "python type",
+            "scope": "support.type.python",
+            "settings": {
+                "foreground": "#99d1db"
+            }
+        },
+        {
+            "name": "python block",
+            "scope": "punctuation.definition.arguments.begin.python,punctuation.definition.arguments.end.python,punctuation.separator.arguments.python,punctuation.definition.list.begin.python,punctuation.definition.list.end.python",
+            "settings": {
+                "foreground": "#c6d0f5"
+            }
+        },
+        {
+            "name": "python function-call.generic",
+            "scope": "meta.function-call.generic.python",
+            "settings": {
+                "foreground": "#8caaee",
+                "fontStyle": "italic"
+            }
+        },
+        {
+            "name": "python placeholder reset to normal string",
+            "scope": "constant.character.format.placeholder.other.python",
+            "settings": {
+                "foreground": "#e5c890"
+            }
+        },
+        {
+            "name": "Operators",
+            "scope": "keyword.operator",
+            "settings": {
+                "foreground": "#99d1db",
+                "fontStyle": "bold"
+            }
+        },
+        {
+            "name": "Keywords",
+            "scope": "keyword",
+            "settings": {
+                "foreground": "#e78284"
+            }
+        },
+        {
+            "name": "Namespaces",
+            "scope": "entity.name.namespace",
+            "settings": {
+                "foreground": "#ef9f76"
+            }
+        },
+        {
+            "name": "Language variables",
+            "scope": "variable.language",
+            "settings": {
+                "foreground": "#ef9f76"
+            }
+        },
+        {
+            "name": "Java Variables",
+            "scope": "token.variable.parameter.java",
+            "settings": {
+                "foreground": "#c6d0f5"
+            }
+        },
+        {
+            "name": "Java Imports",
+            "scope": "import.storage.java",
+            "settings": {
+                "foreground": "#ef9f76"
+            }
+        },
+        {
+            "name": "Packages",
+            "scope": "token.package.keyword",
+            "settings": {
+                "foreground": "#e78284"
+            }
+        },
+        {
+            "name": "Packages",
+            "scope": "token.package",
+            "settings": {
+                "foreground": "#c6d0f5"
+            }
+        },
+        {
+            "name": "Functions",
+            "scope": [
+                "entity.name.function",
+                "meta.require",
+                "support.function.any-method",
+                "variable.function"
+            ],
+            "settings": {
+                "foreground": "#8caaee",
+                "fontStyle": "italic"
+            }
+        },
+        {
+            "name": "Classes",
+            "scope": "entity.name.type.namespace",
+            "settings": {
+                "foreground": "#ef9f76"
+            }
+        },
+        {
+            "name": "Classes",
+            "scope": "support.class, entity.name.type.class",
+            "settings": {
+                "foreground": "#ef9f76"
+            }
+        },
+        {
+            "name": "Class name",
+            "scope": "entity.name.class.identifier.namespace.type",
+            "settings": {
+                "foreground": "#ef9f76"
+            }
+        },
+        {
+            "name": "Class name",
+            "scope": [
+                "entity.name.class",
+                "variable.other.class.js",
+                "variable.other.class.ts"
+            ],
+            "settings": {
+                "foreground": "#ef9f76"
+            }
+        },
+        {
+            "name": "Class name php",
+            "scope": "variable.other.class.php",
+            "settings": {
+                "foreground": "#81c8be"
+            }
+        },
+        {
+            "name": "Type Name",
+            "scope": "entity.name.type",
+            "settings": {
+                "foreground": "#ef9f76"
+            }
+        },
+        {
+            "name": "Keyword Control",
+            "scope": "keyword.control",
+            "settings": {
+                "foreground": "#e78284"
+            }
+        },
+        {
+            "name": "Control Elements",
+            "scope": "control.elements, keyword.operator.less",
+            "settings": {
+                "foreground": "#e5c890"
+            }
+        },
+        {
+            "name": "Methods",
+            "scope": "keyword.other.special-method",
+            "settings": {
+                "foreground": "#8caaee"
+            }
+        },
+        {
+            "name": "Storage",
+            "scope": "storage",
+            "settings": {
+                "foreground": "#e78284"
+            }
+        },
+        {
+            "name": "Storage JS TS",
+            "scope": "token.storage",
+            "settings": {
+                "foreground": "#e78284"
+            }
+        },
+        {
+            "name": "Source Js Keyword Operator Delete,source Js Keyword Operator In,source Js Keyword Operator Of,source Js Keyword Operator Instanceof,source Js Keyword Operator New,source Js Keyword Operator Typeof,source Js Keyword Operator Void",
+            "scope": "keyword.operator.expression.delete,keyword.operator.expression.in,keyword.operator.expression.of,keyword.operator.expression.instanceof,keyword.operator.new,keyword.operator.expression.typeof,keyword.operator.expression.void",
+            "settings": {
+                "foreground": "#e78284"
+            }
+        },
+        {
+            "name": "Java Storage",
+            "scope": "token.storage.type.java",
+            "settings": {
+                "foreground": "#ef9f76"
+            }
+        },
+        {
+            "name": "Support",
+            "scope": "support.function",
+            "settings": {
+                "foreground": "#99d1db"
+            }
+        },
+        {
+            "name": "Support type",
+            "scope": "support.type.property-name",
+            "settings": {
+                "foreground": "#c6d0f5"
+            }
+        },
+        {
+            "name": "Support type",
+            "scope": "support.constant.property-value",
+            "settings": {
+                "foreground": "#c6d0f5"
+            }
+        },
+        {
+            "name": "Support type",
+            "scope": "support.constant.font-name",
+            "settings": {
+                "foreground": "#e5c890"
+            }
+        },
+        {
+            "name": "Meta tag",
+            "scope": "meta.tag",
+            "settings": {
+                "foreground": "#c6d0f5"
+            }
+        },
+        {
+            "name": "Strings",
+            "scope": "string",
+            "settings": {
+                "foreground": "#a6d189"
+            }
+        },
+        {
+            "name": "Inherited Class",
+            "scope": "entity.other.inherited-class",
+            "settings": {
+                "foreground": "#ef9f76"
+            }
+        },
+        {
+            "name": "Constant other symbol",
+            "scope": "constant.other.symbol",
+            "settings": {
+                "foreground": "#99d1db"
+            }
+        },
+        {
+            "name": "Integers",
+            "scope": "constant.numeric",
+            "settings": {
+                "foreground": "#ef9f76"
+            }
+        },
+        {
+            "name": "Constants",
+            "scope": "constant",
+            "settings": {
+                "foreground": "#e5c890"
+            }
+        },
+        {
+            "name": "Constants",
+            "scope": "punctuation.definition.constant",
+            "settings": {
+                "foreground": "#e5c890"
+            }
+        },
+        {
+            "name": "Tags",
+            "scope": "entity.name.tag",
+            "settings": {
+                "foreground": "#81c8be"
+            }
+        },
+        {
+            "name": "Attributes",
+            "scope": "entity.other.attribute-name",
+            "settings": {
+                "foreground": "#e5c890"
+            }
+        },
+        {
+            "name": "Attribute IDs",
+            "scope": "entity.other.attribute-name.id",
+            "settings": {
+                "fontStyle": "",
+                "foreground": "#8caaee"
+            }
+        },
+        {
+            "name": "Attribute class",
+            "scope": "entity.other.attribute-name.class.css",
+            "settings": {
+                "fontStyle": "",
+                "foreground": "#e5c890"
+            }
+        },
+        {
+            "name": "Selector",
+            "scope": "meta.selector",
+            "settings": {
+                "foreground": "#e78284"
+            }
+        },
+        {
+            "name": "Headings",
+            "scope": "markup.heading",
+            "settings": {
+                "foreground": "#81c8be"
+            }
+        },
+        {
+            "name": "Headings",
+            "scope": "markup.heading punctuation.definition.heading, entity.name.section",
+            "settings": {
+                "foreground": "#8caaee"
+            }
+        },
+        {
+            "name": "Units",
+            "scope": "keyword.other.unit",
+            "settings": {
+                "foreground": "#81c8be"
+            }
+        },
+        {
+            "name": "Bold",
+            "scope": "markup.bold,todo.bold",
+            "settings": {
+                "foreground": "#e5c890"
+            }
+        },
+        {
+            "name": "Bold",
+            "scope": "punctuation.definition.bold",
+            "settings": {
+                "foreground": "#ef9f76"
+            }
+        },
+        {
+            "name": "markup Italic",
+            "scope": "markup.italic, punctuation.definition.italic,todo.emphasis",
+            "settings": {
+                "foreground": "#e78284"
+            }
+        },
+        {
+            "name": "emphasis md",
+            "scope": "emphasis md",
+            "settings": {
+                "foreground": "#e78284"
+            }
+        },
+        {
+            "name": "[VSCODE-CUSTOM] Markdown headings",
+            "scope": "entity.name.section.markdown",
+            "settings": {
+                "foreground": "#81c8be"
+            }
+        },
+        {
+            "name": "[VSCODE-CUSTOM] Markdown heading Punctuation Definition",
+            "scope": "punctuation.definition.heading.markdown",
+            "settings": {
+                "foreground": "#81c8be"
+            }
+        },
+        {
+            "name": "punctuation.definition.list.begin.markdown",
+            "scope": "punctuation.definition.list.begin.markdown",
+            "settings": {
+                "foreground": "#81c8be"
+            }
+        },
+        {
+            "name": "[VSCODE-CUSTOM] Markdown heading setext",
+            "scope": "markup.heading.setext",
+            "settings": {
+                "foreground": "#c6d0f5"
+            }
+        },
+        {
+            "name": "[VSCODE-CUSTOM] Markdown Punctuation Definition Bold",
+            "scope": "punctuation.definition.bold.markdown",
+            "settings": {
+                "foreground": "#e5c890"
+            }
+        },
+        {
+            "name": "[VSCODE-CUSTOM] Markdown Inline Raw",
+            "scope": "markup.inline.raw.markdown",
+            "settings": {
+                "foreground": "#a6d189"
+            }
+        },
+        {
+            "name": "[VSCODE-CUSTOM] Markdown Inline Raw",
+            "scope": "markup.inline.raw.string.markdown",
+            "settings": {
+                "foreground": "#a6d189"
+            }
+        },
+        {
+            "name": "[VSCODE-CUSTOM] Markdown List Punctuation Definition",
+            "scope": "punctuation.definition.list.markdown",
+            "settings": {
+                "foreground": "#81c8be"
+            }
+        },
+        {
+            "name": "[VSCODE-CUSTOM] Markdown Punctuation Definition String",
+            "scope": [
+                "punctuation.definition.string.begin.markdown",
+                "punctuation.definition.string.end.markdown",
+                "punctuation.definition.metadata.markdown"
+            ],
+            "settings": {
+                "foreground": "#81c8be"
+            }
+        },
+        {
+            "name": "beginning.punctuation.definition.list.markdown",
+            "scope": ["beginning.punctuation.definition.list.markdown"],
+            "settings": {
+                "foreground": "#81c8be"
+            }
+        },
+        {
+            "name": "[VSCODE-CUSTOM] Markdown Punctuation Definition Link",
+            "scope": "punctuation.definition.metadata.markdown",
+            "settings": {
+                "foreground": "#81c8be"
+            }
+        },
+        {
+            "name": "[VSCODE-CUSTOM] Markdown Underline Link/Image",
+            "scope": "markup.underline.link.markdown,markup.underline.link.image.markdown",
+            "settings": {
+                "foreground": "#e78284"
+            }
+        },
+        {
+            "name": "[VSCODE-CUSTOM] Markdown Link Title/Description",
+            "scope": "string.other.link.title.markdown,string.other.link.description.markdown",
+            "settings": {
+                "foreground": "#8caaee"
+            }
+        },
+        {
+            "name": "Regular Expressions",
+            "scope": "string.regexp",
+            "settings": {
+                "foreground": "#99d1db"
+            }
+        },
+        {
+            "name": "Escape Characters",
+            "scope": "constant.character.escape",
+            "settings": {
+                "foreground": "#99d1db"
+            }
+        },
+        {
+            "name": "Embedded",
+            "scope": "punctuation.section.embedded, variable.interpolation",
+            "settings": {
+                "foreground": "#81c8be"
+            }
+        },
+        {
+            "name": "Embedded",
+            "scope": "punctuation.section.embedded.begin,punctuation.section.embedded.end",
+            "settings": {
+                "foreground": "#e78284"
+            }
+        },
+        {
+            "name": "illegal",
+            "scope": "invalid.illegal",
+            "settings": {
+                "foreground": "#ffffff"
+            }
+        },
+        {
+            "name": "illegal",
+            "scope": "invalid.illegal.bad-ampersand.html",
+            "settings": {
+                "foreground": "#c6d0f5"
+            }
+        },
+        {
+            "name": "Broken",
+            "scope": "invalid.broken",
+            "settings": {
+                "foreground": "#ffffff"
+            }
+        },
+        {
+            "name": "Deprecated",
+            "scope": "invalid.deprecated",
+            "settings": {
+                "foreground": "#ffffff"
+            }
+        },
+        {
+            "name": "Unimplemented",
+            "scope": "invalid.unimplemented",
+            "settings": {
+                "foreground": "#ffffff"
+            }
+        },
+        {
+            "name": "laravel blade tag",
+            "scope": "text.html.laravel-blade source.php.embedded.line.html entity.name.tag.laravel-blade",
+            "settings": {
+                "foreground": "#e78284"
+            }
+        },
+        {
+            "name": "laravel blade @",
+            "scope": "text.html.laravel-blade source.php.embedded.line.html support.constant.laravel-blade",
+            "settings": {
+                "foreground": "#e78284"
+            }
+        },
+        {
+            "name": "use statement for other classes",
+            "scope": "support.other.namespace.use.php,support.other.namespace.use-as.php,support.other.namespace.php,entity.other.alias.php,meta.interface.php",
+            "settings": {
+                "foreground": "#ef9f76"
+            }
+        },
+        {
+            "name": "error suppression",
+            "scope": "keyword.operator.error-control.php",
+            "settings": {
+                "foreground": "#e78284"
+            }
+        },
+        {
+            "name": "php instanceof",
+            "scope": "keyword.operator.type.php",
+            "settings": {
+                "foreground": "#e78284"
+            }
+        },
+        {
+            "name": "style double quoted array index normal begin",
+            "scope": "punctuation.section.array.begin.php",
+            "settings": {
+                "foreground": "#c6d0f5"
+            }
+        },
+        {
+            "name": "style double quoted array index normal end",
+            "scope": "punctuation.section.array.end.php",
+            "settings": {
+                "foreground": "#c6d0f5"
+            }
+        },
+        {
+            "name": "php illegal.non-null-typehinted",
+            "scope": "invalid.illegal.non-null-typehinted.php",
+            "settings": {
+                "foreground": "#f44747"
+            }
+        },
+        {
+            "name": "php types",
+            "scope": "storage.type.php,meta.other.type.phpdoc.php,keyword.other.type.php,keyword.other.array.phpdoc.php",
+            "settings": {
+                "foreground": "#ef9f76"
+            }
+        },
+        {
+            "name": "php call-function",
+            "scope": "meta.function-call.php,meta.function-call.object.php,meta.function-call.static.php",
+            "settings": {
+                "foreground": "#8caaee"
+            }
+        },
+        {
+            "name": "php function-resets",
+            "scope": "punctuation.definition.parameters.begin.bracket.round.php,punctuation.definition.parameters.end.bracket.round.php,punctuation.separator.delimiter.php,punctuation.section.scope.begin.php,punctuation.section.scope.end.php,punctuation.terminator.expression.php,punctuation.definition.arguments.begin.bracket.round.php,punctuation.definition.arguments.end.bracket.round.php,punctuation.definition.storage-type.begin.bracket.round.php,punctuation.definition.storage-type.end.bracket.round.php,punctuation.definition.array.begin.bracket.round.php,punctuation.definition.array.end.bracket.round.php,punctuation.definition.begin.bracket.round.php,punctuation.definition.end.bracket.round.php,punctuation.definition.begin.bracket.curly.php,punctuation.definition.end.bracket.curly.php,punctuation.definition.section.switch-block.end.bracket.curly.php,punctuation.definition.section.switch-block.start.bracket.curly.php,punctuation.definition.section.switch-block.begin.bracket.curly.php,punctuation.definition.section.switch-block.end.bracket.curly.php",
+            "settings": {
+                "foreground": "#c6d0f5"
+            }
+        },
+        {
+            "name": "support php constants",
+            "scope": "support.constant.ext.php,support.constant.std.php,support.constant.core.php,support.constant.parser-token.php",
+            "settings": {
+                "foreground": "#e5c890"
+            }
+        },
+        {
+            "name": "php goto",
+            "scope": "entity.name.goto-label.php,support.other.php",
+            "settings": {
+                "foreground": "#8caaee"
+            }
+        },
+        {
+            "name": "php logical/bitwise operator",
+            "scope": "keyword.operator.logical.php,keyword.operator.bitwise.php,keyword.operator.arithmetic.php",
+            "settings": {
+                "foreground": "#99d1db"
+            }
+        },
+        {
+            "name": "php regexp operator",
+            "scope": "keyword.operator.regexp.php",
+            "settings": {
+                "foreground": "#e78284"
+            }
+        },
+        {
+            "name": "php comparison",
+            "scope": "keyword.operator.comparison.php",
+            "settings": {
+                "foreground": "#99d1db"
+            }
+        },
+        {
+            "name": "php heredoc/nowdoc",
+            "scope": "keyword.operator.heredoc.php,keyword.operator.nowdoc.php",
+            "settings": {
+                "foreground": "#e78284"
+            }
+        },
+        {
+            "name": "python function decorator @",
+            "scope": "meta.function.decorator.python",
+            "settings": {
+                "foreground": "#8caaee"
+            }
+        },
+        {
+            "name": "python function support",
+            "scope": "support.token.decorator.python,meta.function.decorator.identifier.python",
+            "settings": {
+                "foreground": "#99d1db"
+            }
+        },
+        {
+            "name": "parameter function js/ts",
+            "scope": "function.parameter",
+            "settings": {
+                "foreground": "#c6d0f5"
+            }
+        },
+        {
+            "name": "brace function",
+            "scope": "function.brace",
+            "settings": {
+                "foreground": "#c6d0f5"
+            }
+        },
+        {
+            "name": "parameter function ruby cs",
+            "scope": "function.parameter.ruby, function.parameter.cs",
+            "settings": {
+                "foreground": "#c6d0f5"
+            }
+        },
+        {
+            "name": "constant.language.symbol.ruby",
+            "scope": "constant.language.symbol.ruby",
+            "settings": {
+                "foreground": "#99d1db"
+            }
+        },
+        {
+            "name": "rgb-value",
+            "scope": "rgb-value",
+            "settings": {
+                "foreground": "#99d1db"
+            }
+        },
+        {
+            "name": "rgb value",
+            "scope": "inline-color-decoration rgb-value",
+            "settings": {
+                "foreground": "#e5c890"
+            }
+        },
+        {
+            "name": "rgb value less",
+            "scope": "less rgb-value",
+            "settings": {
+                "foreground": "#e5c890"
+            }
+        },
+        {
+            "name": "sass selector",
+            "scope": "selector.sass",
+            "settings": {
+                "foreground": "#81c8be"
+            }
+        },
+        {
+            "name": "ts primitive/builtin types",
+            "scope": "support.type.primitive.ts,support.type.builtin.ts,support.type.primitive.tsx,support.type.builtin.tsx",
+            "settings": {
+                "foreground": "#ef9f76"
+            }
+        },
+        {
+            "name": "block scope",
+            "scope": "block.scope.end,block.scope.begin",
+            "settings": {
+                "foreground": "#c6d0f5"
+            }
+        },
+        {
+            "name": "cs storage type",
+            "scope": "storage.type.cs",
+            "settings": {
+                "foreground": "#ef9f76"
+            }
+        },
+        {
+            "name": "cs local variable",
+            "scope": "entity.name.variable.local.cs",
+            "settings": {
+                "foreground": "#c6d0f5"
+            }
+        },
+        {
+            "scope": "token.info-token",
+            "settings": {
+                "foreground": "#8caaee"
+            }
+        },
+        {
+            "scope": "token.warn-token",
+            "settings": {
+                "foreground": "#e5c890"
+            }
+        },
+        {
+            "scope": "token.error-token",
+            "settings": {
+                "foreground": "#f44747"
+            }
+        },
+        {
+            "scope": "token.debug-token",
+            "settings": {
+                "foreground": "#e78284"
+            }
+        },
+        {
+            "name": "String interpolation",
+            "scope": [
+                "punctuation.definition.template-expression.begin",
+                "punctuation.definition.template-expression.end",
+                "punctuation.section.embedded"
+            ],
+            "settings": {
+                "foreground": "#e78284"
+            }
+        },
+        {
+            "name": "Reset JavaScript string interpolation expression",
+            "scope": ["meta.template.expression"],
+            "settings": {
+                "foreground": "#c6d0f5"
+            }
+        },
+        {
+            "name": "Import module JS",
+            "scope": ["keyword.operator.module"],
+            "settings": {
+                "foreground": "#e78284"
+            }
+        },
+        {
+            "name": "js Flowtype",
+            "scope": ["support.type.type.flowtype"],
+            "settings": {
+                "foreground": "#8caaee"
+            }
+        },
+        {
+            "name": "js Flow",
+            "scope": ["support.type.primitive"],
+            "settings": {
+                "foreground": "#ef9f76"
+            }
+        },
+        {
+            "name": "js class prop",
+            "scope": ["meta.property.object"],
+            "settings": {
+                "foreground": "#81c8be"
+            }
+        },
+        {
+            "name": "js func parameter",
+            "scope": ["variable.parameter.function.js"],
+            "settings": {
+                "foreground": "#81c8be"
+            }
+        },
+        {
+            "name": "js template literals begin",
+            "scope": ["keyword.other.template.begin"],
+            "settings": {
+                "foreground": "#a6d189"
+            }
+        },
+        {
+            "name": "js template literals end",
+            "scope": ["keyword.other.template.end"],
+            "settings": {
+                "foreground": "#a6d189"
+            }
+        },
+        {
+            "name": "js template literals variable braces begin",
+            "scope": ["keyword.other.substitution.begin"],
+            "settings": {
+                "foreground": "#a6d189"
+            }
+        },
+        {
+            "name": "js template literals variable braces end",
+            "scope": ["keyword.other.substitution.end"],
+            "settings": {
+                "foreground": "#a6d189"
+            }
+        },
+        {
+            "name": "go operator",
+            "scope": [
+                "keyword.operator.arithmetic.go",
+                "keyword.operator.address.go"
+            ],
+            "settings": {
+                "foreground": "#e78284"
+            }
+        },
+        {
+            "name": "Go package name",
+            "scope": ["entity.name.package.go"],
+            "settings": {
+                "foreground": "#ef9f76"
+            }
+        },
+        {
+            "name": "elm prelude",
+            "scope": ["support.type.prelude.elm"],
+            "settings": {
+                "foreground": "#99d1db"
+            }
+        },
+        {
+            "name": "elm constant",
+            "scope": ["support.constant.elm"],
+            "settings": {
+                "foreground": "#e5c890"
+            }
+        },
+        {
+            "name": "template literal",
+            "scope": ["punctuation.quasi.element"],
+            "settings": {
+                "foreground": "#e78284"
+            }
+        },
+        {
+            "name": "html/pug (jade) escaped characters and entities",
+            "scope": ["constant.character.entity"],
+            "settings": {
+                "foreground": "#81c8be"
+            }
+        },
+        {
+            "name": "styling css pseudo-elements/classes to be able to differentiate from classes which are the same colour",
+            "scope": [
+                "entity.other.attribute-name.pseudo-element",
+                "entity.other.attribute-name.pseudo-class"
+            ],
+            "settings": {
+                "foreground": "#99d1db"
+            }
+        },
+        {
+            "name": "Clojure globals",
+            "scope": ["entity.global.clojure"],
+            "settings": {
+                "foreground": "#ef9f76"
+            }
+        },
+        {
+            "name": "Clojure symbols",
+            "scope": ["meta.symbol.clojure"],
+            "settings": {
+                "foreground": "#81c8be"
+            }
+        },
+        {
+            "name": "Clojure constants",
+            "scope": ["constant.keyword.clojure"],
+            "settings": {
+                "foreground": "#99d1db"
+            }
+        },
+        {
+            "name": "CoffeeScript Function Argument",
+            "scope": [
+                "meta.arguments.coffee",
+                "variable.parameter.function.coffee"
+            ],
+            "settings": {
+                "foreground": "#81c8be"
+            }
+        },
+        {
+            "name": "Ini Default Text",
+            "scope": ["source.ini"],
+            "settings": {
+                "foreground": "#a6d189"
+            }
+        },
+
+        {
+            "name": "Shell definition variables",
+            "scope": ["punctuation.definition.variable.shell"],
+            "settings": {
+                "foreground": "#838ba7"
+            }
+        },
+        {
+            "name": "Shell logical operators",
+            "scope": ["keyword.operator.logical.shell"],
+            "settings": {
+                "foreground": "#99d1db"
+            }
+        },
+        {
+            "name": "Shell clauses",
+            "scope": ["meta.scope.case-clause-body.shell"],
+            "settings": {
+                "foreground": "#c6d0f5"
+            }
+        },
+        {
+            "name": "Shell funcs",
+            "scope": ["meta.scope.group.shell"],
+            "settings": {
+                "foreground": "#8caaee"
+            }
+        },
+        {
+            "name": "Shell interpolated cmds",
+            "scope": ["string.interpolated.dollar.shell"],
+            "settings": {
+                "foreground": "#e5c890"
+            }
+        },
+        {
+            "name": "Shell interpolated strings",
+            "scope": ["string.quoted.single.shell"],
+            "settings": {
+                "foreground": "#babbf1"
+            }
+        },
+        {
+            "name": "Shell pipe symbol",
+            "scope": ["keyword.operator.pipe.shell"],
+            "settings": {
+                "foreground": "#99d1db"
+            }
+        },
+        {
+            "name": "Shell group definition",
+            "scope": ["punctuation.definition.group.shell"],
+            "settings": {
+                "foreground": "#838ba7"
+            }
+        },
+        {
+            "name": "Shell conditionals",
+            "scope": ["keyword.control.shell"],
+            "settings": {
+                "foreground": "#ca9ee6"
+            }
+        },
+        {
+            "name": "Shell opeartors and punct delimeters",
+            "scope": ["keyword.operator.list.shell"],
+            "settings": {
+                "foreground": "#81c8be"
+            }
+        },
+        {
+            "name": "Shell parenthesis",
+            "scope": ["punctuation.definition.logical-expression.shell"],
+            "settings": {
+                "foreground": "#838ba7"
+            }
+        },
+
+        {
+            "name": "Makefile prerequisities",
+            "scope": ["meta.scope.prerequisites.makefile"],
+            "settings": {
+                "foreground": "#81c8be"
+            }
+        },
+        {
+            "name": "Makefile text colour",
+            "scope": ["source.makefile"],
+            "settings": {
+                "foreground": "#ef9f76"
+            }
+        },
+        {
+            "name": "Groovy import names",
+            "scope": ["storage.modifier.import.groovy"],
+            "settings": {
+                "foreground": "#ef9f76"
+            }
+        },
+        {
+            "name": "Groovy Methods",
+            "scope": ["meta.method.groovy"],
+            "settings": {
+                "foreground": "#8caaee"
+            }
+        },
+        {
+            "name": "Groovy Variables",
+            "scope": ["meta.definition.variable.name.groovy"],
+            "settings": {
+                "foreground": "#81c8be"
+            }
+        },
+        {
+            "name": "Groovy Inheritance",
+            "scope": ["meta.definition.class.inherited.classes.groovy"],
+            "settings": {
+                "foreground": "#a6d189"
+            }
+        },
+        {
+            "name": "HLSL Semantic",
+            "scope": ["support.variable.semantic.hlsl"],
+            "settings": {
+                "foreground": "#ef9f76"
+            }
+        },
+        {
+            "name": "HLSL Types",
+            "scope": [
+                "support.type.texture.hlsl",
+                "support.type.sampler.hlsl",
+                "support.type.object.hlsl",
+                "support.type.object.rw.hlsl",
+                "support.type.fx.hlsl",
+                "support.type.object.hlsl"
+            ],
+            "settings": {
+                "foreground": "#e78284"
+            }
+        },
+        {
+            "name": "SQL Variables",
+            "scope": ["text.variable", "text.bracketed"],
+            "settings": {
+                "foreground": "#81c8be"
+            }
+        },
+        {
+            "name": "types",
+            "scope": ["support.type.swift", "support.type.vb.asp"],
+            "settings": {
+                "foreground": "#ef9f76"
+            }
+        },
+        {
+            "name": "heading 1, keyword",
+            "scope": ["entity.name.function.xi"],
+            "settings": {
+                "foreground": "#8caaee"
+            }
+        },
+        {
+            "name": "heading 2, callable",
+            "scope": ["entity.name.class.xi"],
+            "settings": {
+                "foreground": "#99d1db"
+            }
+        },
+        {
+            "name": "heading 3, property",
+            "scope": ["constant.character.character-class.regexp.xi"],
+            "settings": {
+                "foreground": "#81c8be"
+            }
+        },
+        {
+            "name": "heading 4, type, class, interface",
+            "scope": ["constant.regexp.xi"],
+            "settings": {
+                "foreground": "#e78284"
+            }
+        },
+        {
+            "name": "heading 5, enums, preprocessor, constant, decorator",
+            "scope": ["keyword.control.xi"],
+            "settings": {
+                "foreground": "#99d1db"
+            }
+        },
+        {
+            "name": "heading 6, number",
+            "scope": ["invalid.xi"],
+            "settings": {
+                "foreground": "#c6d0f5"
+            }
+        },
+        {
+            "name": "string",
+            "scope": ["beginning.punctuation.definition.quote.markdown.xi"],
+            "settings": {
+                "foreground": "#a6d189"
+            }
+        },
+        {
+            "name": "comments",
+            "scope": ["beginning.punctuation.definition.list.markdown.xi"],
+            "settings": {
+                "foreground": "#737994"
+            }
+        },
+        {
+            "name": "link",
+            "scope": ["constant.character.xi"],
+            "settings": {
+                "foreground": "#8caaee"
+            }
+        },
+        {
+            "name": "accent",
+            "scope": ["accent.xi"],
+            "settings": {
+                "foreground": "#8caaee"
+            }
+        },
+        {
+            "name": "wikiword",
+            "scope": ["wikiword.xi"],
+            "settings": {
+                "foreground": "#e5c890"
+            }
+        },
+        {
+            "name": "language operators like '+', '-' etc",
+            "scope": ["constant.other.color.rgb-value.xi"],
+            "settings": {
+                "foreground": "#ffffff"
+            }
+        },
+        {
+            "name": "elements to dim",
+            "scope": ["punctuation.definition.tag.xi"],
+            "settings": {
+                "foreground": "#737994"
+            }
+        },
+        {
+            "name": "Markdown underscore-style headers",
+            "scope": [
+                "entity.name.label.cs",
+                "markup.heading.setext.1.markdown",
+                "markup.heading.setext.2.markdown"
+            ],
+            "settings": {
+                "foreground": "#81c8be"
+            }
+        },
+        {
+            "name": "meta.brace.square",
+            "scope": [" meta.brace.square"],
+            "settings": {
+                "foreground": "#c6d0f5"
+            }
+        },
+        {
+            "name": "Comments",
+            "scope": "comment, punctuation.definition.comment",
+            "settings": {
+                "fontStyle": "italic",
+                "foreground": "#737994"
+            }
+        },
+        {
+            "name": "[VSCODE-CUSTOM] Markdown Quote",
+            "scope": "markup.quote.markdown",
+            "settings": {
+                "foreground": "#737994"
+            }
+        },
+        {
+            "name": "punctuation.definition.block.sequence.item.yaml",
+            "scope": "punctuation.definition.block.sequence.item.yaml",
+            "settings": {
+                "foreground": "#c6d0f5"
+            }
+        },
+        {
+            "scope": ["constant.language.symbol.elixir"],
+            "settings": {
+                "foreground": "#99d1db"
+            }
+        },
+        {
+            "name": "js/ts italic",
+            "scope": "entity.other.attribute-name.js,entity.other.attribute-name.ts,entity.other.attribute-name.jsx,entity.other.attribute-name.tsx,variable.parameter,variable.language.super",
+            "settings": {
+                "fontStyle": "italic"
+            }
+        },
+        {
+            "name": "comment",
+            "scope": "comment.line.double-slash,comment.block.documentation",
+            "settings": {
+                "fontStyle": "italic"
+            }
+        },
+        {
+            "name": "python keyword import",
+            "scope": "keyword.control.import.python",
+            "settings": {
+                "foreground": "#81c8be",
+                "fontStyle": "italic"
+            }
+        },
+        {
+            "name": "python keyword flow",
+            "scope": "keyword.control.flow.python",
+            "settings": {
+                "foreground": "#ca9ee6",
+                "fontStyle": "bold"
+            }
+        },
+        {
+            "name": "python storage type",
+            "scope": "storage.type.function.python",
+            "settings": {
+                "foreground": "#ea999c",
+                "fontStyle": "italic"
+            }
+        },
+        {
+            "name": "markup.italic.markdown",
+            "scope": "markup.italic.markdown",
+            "settings": {
+                "fontStyle": "italic"
+            }
+        }
+    ],
+    "colors": {
+        "foreground": "#c6d0f5",
+        "focusBorder": "#8caaee",
+        "selection.background": "#737994",
+        "scrollbar.shadow": "#303446",
+        "activityBar.foreground": "#c6d0f5",
+        "activityBar.background": "#303446",
+        "activityBar.inactiveForeground": "#c6d0f55a",
+        "activityBarBadge.foreground": "#303446",
+        "activityBarBadge.background": "#8caaee",
+        "sideBar.background": "#292c3c",
+        "sideBar.foreground": "#c6d0f5",
+        "sideBarSectionHeader.background": "#00000000",
+        "sideBarSectionHeader.foreground": "#c6d0f5",
+        "sideBarTitle.foreground": "#c6d0f5",
+        "list.inactiveSelectionBackground": "#303446",
+        "list.inactiveSelectionForeground": "#c6d0f5",
+        "list.hoverBackground": "#303446",
+        "list.hoverForeground": "#c6d0f5",
+        "list.activeSelectionBackground": "#626880",
+        "list.activeSelectionForeground": "#c6d0f5",
+        "tree.indentGuidesStroke": "#737994",
+        "list.dropBackground": "#303446",
+        "list.highlightForeground": "#8caaee",
+        "list.focusBackground": "#51576d",
+        "list.focusForeground": "#c6d0f5",
+        "listFilterWidget.background": "#51576d",
+        "listFilterWidget.outline": "#00000000",
+        "listFilterWidget.noMatchesOutline": "#e78284",
+        "statusBar.foreground": "#c6d0f5",
+        "statusBar.background": "#51576d",
+        "statusBarItem.hoverBackground": "#ffffff1f",
+        "statusBar.debuggingBackground": "#e78284",
+        "statusBar.debuggingForeground": "#51576d",
+        "statusBar.noFolderBackground": "#ca9ee6",
+        "statusBar.noFolderForeground": "#51576d",
+        "statusBarItem.remoteBackground": "#a6d189",
+        "statusBarItem.remoteForeground": "#51576d",
+        "titleBar.activeBackground": "#303446",
+        "titleBar.activeForeground": "#c6d0f5",
+        "titleBar.inactiveBackground": "#30344691",
+        "titleBar.inactiveForeground": "#c6d0f580",
+        "titleBar.border": "#00000000",
+        "menubar.selectionForeground": "#c6d0f5",
+        "menubar.selectionBackground": "#51576d",
+        "menu.foreground": "#c6d0f5",
+        "menu.background": "#51576d",
+        "menu.selectionForeground": "#c6d0f5",
+        "menu.selectionBackground": "#626880",
+        "menu.selectionBorder": "#00000000",
+        "menu.separatorBackground": "#c6d0f5",
+        "menu.border": "#00000085",
+        "button.background": "#626880",
+        "button.foreground": "#c6d0f5",
+        "button.hoverBackground": "#51576d",
+        "button.secondaryForeground": "#c6d0f5",
+        "button.secondaryBackground": "#51576d",
+        "button.secondaryHoverBackground": "#303446",
+        "input.background": "#303446",
+        "input.border": "#00000000",
+        "input.foreground": "#c6d0f5",
+        "inputOption.activeBackground": "#8caaee26",
+        "inputOption.activeBorder": "#8caaee00",
+        "inputOption.activeForeground": "#c6d0f5",
+        "input.placeholderForeground": "#c6d0f570",
+        "textLink.foreground": "#8caaee",
+        "editor.background": "#303446",
+        "editor.foreground": "#c6d0f5",
+        "editorLineNumber.foreground": "#838ba7",
+        "editorCursor.foreground": "#f2d5cf",
+        "editorCursor.background": "#303446",
+        "editor.selectionBackground": "#626880",
+        "editor.inactiveSelectionBackground": "#FFFFFF20",
+        "editorWhitespace.foreground": "#949cbb18",
+        "editor.selectionHighlightBackground": "#949cbb5e",
+        "editor.selectionHighlightBorder": "#99d1db30",
+        "editor.findMatchBackground": "#626880",
+        "editor.findMatchBorder": "#8caaee6a",
+        "editor.findMatchHighlightBackground": "#ef9f765e",
+        "editor.findMatchHighlightBorder": "#ffffff00",
+        "editor.findRangeHighlightBackground": "#62688048",
+        "editor.findRangeHighlightBorder": "#ffffff00",
+        "editor.rangeHighlightBackground": "#8caaee3c",
+        "editor.rangeHighlightBorder": "#ffffff00",
+        "editor.hoverHighlightBackground": "#8caaee3c",
+        "editor.wordHighlightStrongBackground": "#626880",
+        "editor.wordHighlightBackground": "#575757b8",
+        "editor.lineHighlightBackground": "#ffffff0A",
+        "editor.lineHighlightBorder": "#303446",
+        "editorLineNumber.activeForeground": "#a6d189",
+        "editorLink.activeForeground": "#8caaee",
+        "editorIndentGuide.background": "#51576d",
+        "editorIndentGuide.activeBackground": "#626880",
+        "editorRuler.foreground": "#626880",
+        "editorBracketMatch.background": "#949cbb14",
+        "editorBracketMatch.border": "#949cbb",
+        "editor.foldBackground": "#8caaee42",
+        "editorOverviewRuler.background": "#25252500",
+        "editorOverviewRuler.border": "#FFFFFF0F",
+        "editorError.foreground": "#e78284",
+        "editorError.background": "#B73A3400",
+        "editorError.border": "#ffffff00",
+        "editorWarning.foreground": "#e5c890",
+        "editorWarning.background": "#A9904000",
+        "editorWarning.border": "#ffffff00",
+        "editorInfo.foreground": "#8caaee",
+        "editorInfo.background": "#4490BF00",
+        "editorInfo.border": "#4490BF00",
+        "editorGutter.background": "#303446",
+        "editorGutter.modifiedBackground": "#99d1db",
+        "editorGutter.addedBackground": "#a6d189",
+        "editorGutter.deletedBackground": "#e78284",
+        "editorGutter.foldingControlForeground": "#949cbb",
+        "editorCodeLens.foreground": "#838ba7",
+        "editorGroup.border": "#626880",
+        // test
+        "diffEditor.insertedTextBackground": "#a6d18918",
+        "diffEditor.removedTextBackground": "#e782841c",
+        "diffEditor.border": "#626880",
+        "panel.background": "#303446",
+        "panel.border": "#626880",
+        "panelTitle.activeBorder": "#c6d0f5",
+        "panelTitle.activeForeground": "#c6d0f5",
+        "panelTitle.inactiveForeground": "#c6d0f5ad",
+        "badge.background": "#51576d",
+        "badge.foreground": "#c6d0f5",
+        "terminal.foreground": "#c6d0f5",
+        "terminal.selectionBackground": "#62688034",
+        "terminalCursor.background": "#303446",
+        "terminalCursor.foreground": "#f2d5cf",
+        "terminal.border": "#626880",
+        "terminal.ansiBlack": "#737994",
+        "terminal.ansiBlue": "#8caaee",
+        "terminal.ansiBrightBlack": "#838ba7",
+        "terminal.ansiBrightBlue": "#8caaee",
+        "terminal.ansiBrightCyan": "#99d1db",
+        "terminal.ansiBrightGreen": "#a6d189",
+        "terminal.ansiBrightMagenta": "#f4b8e4",
+        "terminal.ansiBrightRed": "#e78284",
+        "terminal.ansiBrightWhite": "#c6d0f5",
+        "terminal.ansiBrightYellow": "#e5c890",
+        "terminal.ansiCyan": "#99d1db",
+        "terminal.ansiGreen": "#a6d189",
+        "terminal.ansiMagenta": "#f4b8e4",
+        "terminal.ansiRed": "#e78284",
+        "terminal.ansiWhite": "#949cbb",
+        "terminal.ansiYellow": "#e5c890",
+        "breadcrumb.background": "#303446",
+        "breadcrumb.foreground": "#c6d0f5cd",
+        "breadcrumb.focusForeground": "#c6d0f5",
+        "editorGroupHeader.tabsBackground": "#303446",
+        "tab.activeForeground": "#c6d0f5",
+        "tab.border": "#51576d",
+        "tab.activeBackground": "#303446",
+        "tab.activeBorder": "#00000000",
+        "tab.activeBorderTop": "#00000000",
+        "tab.inactiveBackground": "#51576d",
+        "tab.inactiveForeground": "#c6d0f564",
+        "scrollbarSlider.background": "#6268807e",
+        "scrollbarSlider.hoverBackground": "#737994",
+        "scrollbarSlider.activeBackground": "#bfbfbf66",
+        "progressBar.background": "#8caaee",
+        "widget.shadow": "#00000080",
+        "editorWidget.foreground": "#c6d0f5",
+        "editorWidget.background": "#303446",
+        "editorWidget.resizeBorder": "#626880",
+        "pickerGroup.border": "#8caaee",
+        "pickerGroup.foreground": "#8caaee",
+        "debugToolBar.background": "#51576d",
+        "debugToolBar.border": "#626880",
+        "notifications.foreground": "#c6d0f5",
+        "notifications.background": "#51576d",
+        "notificationToast.border": "#626880",
+        "notificationsErrorIcon.foreground": "#e78284",
+        "notificationsWarningIcon.foreground": "#e5c890",
+        "notificationsInfoIcon.foreground": "#8caaee",
+        "notificationCenter.border": "#626880",
+        "notificationCenterHeader.foreground": "#c6d0f5",
+        "notificationCenterHeader.background": "#303446",
+        "notifications.border": "#51576d",
+        "gitDecoration.addedResourceForeground": "#a6d189",
+        "gitDecoration.conflictingResourceForeground": "#ca9ee6",
+        "gitDecoration.deletedResourceForeground": "#e78284",
+        "gitDecoration.ignoredResourceForeground": "#737994",
+        "gitDecoration.modifiedResourceForeground": "#e5c890",
+        "gitDecoration.stageDeletedResourceForeground": "#e78284",
+        "gitDecoration.stageModifiedResourceForeground": "#e5c890",
+        "gitDecoration.submoduleResourceForeground": "#8caaee",
+        "gitDecoration.untrackedResourceForeground": "#a6d189",
+        "editorMarkerNavigation.background": "#51576d",
+        "editorMarkerNavigationError.background": "#e78284",
+        "editorMarkerNavigationWarning.background": "#e5c890",
+        "editorMarkerNavigationInfo.background": "#8caaee",
+        "merge.currentHeaderBackground": "#158472",
+        "merge.currentContentBackground": "#27403B",
+        "merge.incomingHeaderBackground": "#395F8F",
+        "merge.incomingContentBackground": "#243A5E",
+        "merge.commonHeaderBackground": "#626880",
+        "merge.commonContentBackground": "#51576d",
+        "editorSuggestWidget.background": "#51576d",
+        "editorSuggestWidget.border": "#626880",
+        "editorSuggestWidget.foreground": "#c6d0f5",
+        "editorSuggestWidget.highlightForeground": "#8caaee",
+        "editorSuggestWidget.selectedBackground": "#626880",
+        "editorHoverWidget.foreground": "#c6d0f5",
+        "editorHoverWidget.background": "#51576d",
+        "editorHoverWidget.border": "#626880",
+        "peekView.border": "#8caaee",
+        "peekViewEditor.background": "#51576d",
+        "peekViewEditorGutter.background": "#51576d",
+        "peekViewEditor.matchHighlightBackground": "#ef9f7640",
+        "peekViewEditor.matchHighlightBorder": "#ef9f76",
+        "peekViewResult.background": "#51576d",
+        "peekViewResult.fileForeground": "#c6d0f5",
+        "peekViewResult.lineForeground": "#c6d0f5",
+        "peekViewResult.matchHighlightBackground": "#ef9f7640",
+        "peekViewResult.selectionBackground": "#626880",
+        "peekViewResult.selectionForeground": "#c6d0f5",
+        "peekViewTitle.background": "#303446",
+        "peekViewTitleDescription.foreground": "#ccccccb3",
+        "peekViewTitleLabel.foreground": "#c6d0f5",
+        "icon.foreground": "#c6d0f5",
+        "checkbox.background": "#303446",
+        "checkbox.foreground": "#c6d0f5",
+        "checkbox.border": "#00000000",
+        "dropdown.background": "#303446",
+        "dropdown.foreground": "#c6d0f5",
+        "dropdown.border": "#00000000",
+        "minimapGutter.addedBackground": "#a6d189",
+        "minimapGutter.modifiedBackground": "#99d1db",
+        "minimapGutter.deletedBackground": "#e78284",
+        "minimap.findMatchHighlight": "#626880",
+        "minimap.selectionHighlight": "#626880",
+        "minimap.errorHighlight": "#e78284",
+        "minimap.warningHighlight": "#e5c890",
+        "minimap.background": "#303446",
+        "sideBar.dropBackground": "#292c3c",
+        "editorGroup.emptyBackground": "#303446",
+        "panelSection.border": "#626880",
+        "statusBarItem.activeBackground": "#FFFFFF25",
+        "settings.headerForeground": "#c6d0f5",
+        "settings.focusedRowBackground": "#ffffff07",
+        "walkThrough.embeddedEditorBackground": "#00000050",
+        "breadcrumb.activeSelectionForeground": "#c6d0f5",
+        "editorGutter.commentRangeForeground": "#949cbb",
+        "debugExceptionWidget.background": "#51576d",
+        "debugExceptionWidget.border": "#626880",
+        "activitusbar.inactiveColour": "#000000",
+        "activitusbar.activeColour": "#000000"
+    }
+}

--- a/themes/Catppuccin-latte-color-theme.json
+++ b/themes/Catppuccin-latte-color-theme.json
@@ -1,0 +1,2469 @@
+{
+    "name": "Catppuccin Latte",
+    "type": "light",
+    "semanticHighlighting": true,
+    "semanticTokenColors": {
+        "enumMember": {
+            "foreground": "#04a5e5"
+        },
+        "variable.constant": {
+            "foreground": "#df8e1d"
+        },
+        "variable.defaultLibrary": {
+            "foreground": "#fe640b"
+        }
+    },
+    "tokenColors": [
+        {
+            "name": "All variable",
+            "scope": ["variable.language", "variable.other"],
+            "settings": {
+                "foreground": "#dd7878"
+            }
+        },
+        {
+            "name": "All function",
+            "scope": ["entity.name.function", "support.function"],
+            "settings": {
+                "foreground": "#1e66f5",
+                "fontStyle": "italic"
+            }
+        },
+        {
+            "name": "All parameter",
+            "scope": [
+                "variable.parameter.function",
+                "variable.parameter.function-call"
+            ],
+            "settings": {
+                "foreground": "#ea76cb",
+                "fontStyle": "italic"
+            }
+        },
+        {
+            "name": "All numeric",
+            "scope": ["constant.numeric.decimal", "constant.numeric.integer"],
+            "settings": {
+                "foreground": "#fe640b",
+                "fontStyle": "bold"
+            }
+        },
+        {
+            "name": "All types",
+            "scope": "entity.name.type",
+            "settings": {
+                "foreground": "#1e66f5"
+            }
+        },
+        {
+            "name": "All conditionals",
+            "scope": [
+                "keyword.control",
+                "keyword.control.for",
+                "keyword.control.while",
+                "keyword.control.if",
+                "keyword.control.else",
+                "keyword.control.switch",
+                "keyword.control.case"
+            ],
+            "settings": {
+                "foreground": "#d20f39",
+                "fontStyle": "bold"
+            }
+        },
+        {
+            "name": "All punctuation brackets",
+            "scope": [
+                "punctuation.brackets",
+                "punctuation.section",
+                "punctuation.definition"
+            ],
+            "settings": {
+                "foreground": "#8c8fa1"
+            }
+        },
+        {
+            "name": "All punctuation delimeters",
+            "scope": "punctuation.semi",
+            "settings": {
+                "foreground": "#179299"
+            }
+        },
+        {
+            "name": "All namespace",
+            "scope": "entity.name.namespace",
+            "settings": {
+                "foreground": "#dc8a78"
+            }
+        },
+        {
+            "name": "All operators",
+            "scope": [
+                "keyword.operator.comparison",
+                "keyword.operator.assignment",
+                "keyword.operator.arrow.skinny",
+                "keyword.operator.math",
+                "keyword.operator.key-value",
+                "keyword.operator.misc",
+                "keyword.operator.namespace"
+            ],
+            "settings": {
+                "foreground": "#04a5e5",
+                "fontStyle": "bold"
+            }
+        },
+        {
+            "name": "All built-in constants",
+            "scope": "constant.language",
+            "settings": {
+                "foreground": "#7287fd",
+                "fontStyle": "italic"
+            }
+        },
+        {
+            "name": "All constants",
+            "scope": "constant.other",
+            "settings": {
+                "foreground": "#fe640b"
+            }
+        },
+        {
+            "name": "JSON quoted string",
+            "scope": "source.json meta.structure.dictionary.json > string.quoted.json",
+            "settings": {
+                "foreground": "#179299"
+            }
+        },
+        {
+            "name": "JSON punctuation string",
+            "scope": "source.json meta.structure.dictionary.json > string.quoted.json > punctuation.string",
+            "settings": {
+                "foreground": "#179299"
+            }
+        },
+        {
+            "name": "JSON punct structure",
+            "scope": "source.json meta.structure.dictionary.json > value.json > string.quoted.json,source.json meta.structure.array.json > value.json > string.quoted.json,source.json meta.structure.dictionary.json > value.json > string.quoted.json > punctuation,source.json meta.structure.array.json > value.json > string.quoted.json > punctuation",
+            "settings": {
+                "foreground": "#40a02b"
+            }
+        },
+        {
+            "name": "JSON property name",
+            "scope": "support.type.property-name.json.comments",
+            "settings": {
+                "foreground": "#1e66f5"
+            }
+        },
+        {
+            "name": "JSON constants",
+            "scope": "constant.language.json.comments",
+            "settings": {
+                "foreground": "#fe640b"
+            }
+        },
+        {
+            "name": "JSON punctuation",
+            "scope": [
+                "punctuation.separator.dictionary.pair.json.comments",
+                "punctuation.separator.array.json.comments"
+            ],
+            "settings": {
+                "foreground": "#179299"
+            }
+        },
+        {
+            "name": "JSON brackets",
+            "scope": [
+                "punctuation.definition.dictionary.begin.json.comments",
+                "punctuation.definition.dictionary.end.json.comments",
+                "punctuation.definition.array.begin.json.comments",
+                "punctuation.definition.array.end.json.comments"
+            ],
+            "settings": {
+                "foreground": "#7c7f93"
+            }
+        },
+        {
+            "name": "JSON constant language",
+            "scope": "source.json meta.structure.dictionary.json > constant.language.json,source.json meta.structure.array.json > constant.language.json",
+            "settings": {
+                "foreground": "#04a5e5"
+            }
+        },
+        {
+            "name": "JSON property name [VSCODE-CUSTOM]",
+            "scope": "support.type.property-name.json",
+            "settings": {
+                "foreground": "#179299"
+            }
+        },
+        {
+            "name": "[VSCODE-CUSTOM] JSON Punctuation for Property Name",
+            "scope": "support.type.property-name.json punctuation",
+            "settings": {
+                "foreground": "#179299"
+            }
+        },
+
+        {
+            "name": "unison punctuation",
+            "scope": "punctuation.definition.delayed.unison,punctuation.definition.list.begin.unison,punctuation.definition.list.end.unison,punctuation.definition.ability.begin.unison,punctuation.definition.ability.end.unison,punctuation.operator.assignment.as.unison,punctuation.separator.pipe.unison,punctuation.separator.delimiter.unison,punctuation.definition.hash.unison",
+            "settings": {
+                "foreground": "#179299"
+            }
+        },
+        {
+            "name": "haskell variable generic-type",
+            "scope": "variable.other.generic-type.haskell",
+            "settings": {
+                "foreground": "#d20f39"
+            }
+        },
+        {
+            "name": "haskell storage type",
+            "scope": "storage.type.haskell",
+            "settings": {
+                "foreground": "#df8e1d"
+            }
+        },
+        {
+            "name": "support.variable.magic.python",
+            "scope": "support.variable.magic.python",
+            "settings": {
+                "foreground": "#4c4f69"
+            }
+        },
+        {
+            "name": "punctuation.separator.parameters.python",
+            "scope": "punctuation.separator.period.python,punctuation.separator.element.python,punctuation.parenthesis.begin.python,punctuation.parenthesis.end.python",
+            "settings": {
+                "foreground": "#4c4f69"
+            }
+        },
+        {
+            "name": "variable.parameter.function.language.special.self.python",
+            "scope": "variable.parameter.function.language.special.self.python",
+            "settings": {
+                "foreground": "#fe640b"
+            }
+        },
+
+        {
+            "name": "Rust modifier",
+            "scope": "storage.modifier.lifetime.rust",
+            "settings": {
+                "foreground": "#4c4f69"
+            }
+        },
+        {
+            "name": "Rust types",
+            "scope": "entity.name.type.rust",
+            "settings": {
+                "foreground": "#df8e1d"
+            }
+        },
+        {
+            "name": "Rust functions std",
+            "scope": "support.function.std.rust",
+            "settings": {
+                "foreground": "#1e66f5"
+            }
+        },
+        {
+            "name": "Rust functions",
+            "scope": "entity.name.function.rust",
+            "settings": {
+                "foreground": "#1e66f5",
+                "fontStyle": "italic"
+            }
+        },
+        {
+            "name": "Rust function keyword",
+            "scope": "keyword.other.fn.rust",
+            "settings": {
+                "foreground": "#e64553"
+            }
+        },
+        {
+            "name": "Rust conditionals",
+            "scope": "keyword.control.rust",
+            "settings": {
+                "foreground": "#8839ef",
+                "fontStyle": "bold"
+            }
+        },
+        {
+            "name": "Rust punctuation brackets",
+            "scope": [
+                "punctuation.brackets.curly.rust",
+                "punctuation.brackets.round.rust",
+                "punctuation.brackets.square.rust",
+                "punctuation.brackets.attribute.rust"
+            ],
+            "settings": {
+                "foreground": "#8c8fa1"
+            }
+        },
+        {
+            "name": "Rust namespace",
+            "scope": "entity.name.namespace.rust",
+            "settings": {
+                "foreground": "#dc8a78"
+            }
+        },
+        {
+            "name": "Rust punctuation delimeters",
+            "scope": "punctuation.semi.rust",
+            "settings": {
+                "foreground": "#179299"
+            }
+        },
+        {
+            "name": "Rust operators",
+            "scope": [
+                "keyword.operator.comparison.rust",
+                "keyword.operator.assignment.equal.rust",
+                "keyword.operator.arrow.skinny.rust",
+                "keyword.operator.math.rust",
+                "keyword.operator.key-value.rust",
+                "keyword.operator.misc.rust"
+            ],
+            "settings": {
+                "foreground": "#04a5e5"
+            }
+        },
+        {
+            "name": "Rust operator namespaces",
+            "scope": "keyword.operator.namespace.rust",
+            "settings": {
+                "foreground": "#179299"
+            }
+        },
+        {
+            "name": "Rust definition attributes",
+            "scope": [
+                "punctuation.definition.attribute.rust",
+                "keyword.operator.attribute.inner.rust"
+            ],
+            "settings": {
+                "foreground": "#179299",
+                "fontStyle": "bold"
+            }
+        },
+        {
+            "name": "Rust math logic",
+            "scope": "constant.numeric.decimal.rust",
+            "settings": {
+                "foreground": "#fe640b"
+            }
+        },
+        {
+            "name": "Rust constants",
+            "scope": "support.constant.core.rust",
+            "settings": {
+                "foreground": "#df8e1d"
+            }
+        },
+        {
+            "name": "Rust entity name",
+            "scope": "entity.name.lifetime.rust",
+            "settings": {
+                "foreground": "#fe640b"
+            }
+        },
+        {
+            "name": "Rust variable",
+            "scope": ["variable.language.rust", "variable.other.rust"],
+            "settings": {
+                "foreground": "#4c4f69",
+                "fontStyle": "italic"
+            }
+        },
+        {
+            "name": "Rust misc operators",
+            "scope": "keyword.operator.misc.rust",
+            "settings": {
+                "foreground": "#4c4f69"
+            }
+        },
+        {
+            "name": "Rust sigil operator",
+            "scope": "keyword.operator.sigil.rust",
+            "settings": {
+                "foreground": "#d20f39"
+            }
+        },
+
+        {
+            "name": "Lua operators",
+            "scope": "keyword.operator.lua",
+            "settings": {
+                "foreground": "#04a5e5",
+                "fontStyle": "bold"
+            }
+        },
+        {
+            "name": "Lua numeric",
+            "scope": "constant.numeric.integer.lua",
+            "settings": {
+                "foreground": "#fe640b",
+                "fontStyle": "bold"
+            }
+        },
+        {
+            "name": "Lua other vars",
+            "scope": "variable.other.lua",
+            "settings": {
+                "foreground": "#7287fd",
+                "fontStyle": "italic"
+            }
+        },
+        {
+            "name": "Lua brackets",
+            "scope": [
+                "punctuation.definition.parameters.end.lua",
+                "punctuation.definition.parameters.begin.lua"
+            ],
+            "settings": {
+                "foreground": "#8c8fa1"
+            }
+        },
+
+        {
+            "name": "C++ Puct Delimeters",
+            "scope": "punctuation.terminator.statement.cpp",
+            "settings": {
+                "foreground": "#179299",
+                "fontStyle": "bold"
+            }
+        },
+        {
+            "name": "C++ Operators",
+            "scope": [
+                "punctuation.separator.scope-resolution.cpp",
+                "punctuation.separator.scope-resolution.namespace.alias.cpp",
+                "punctuation.separator.scope-resolution.namespace.using.cpp"
+            ],
+            "settings": {
+                "foreground": "#04a5e5",
+                "fontStyle": "bold"
+            }
+        },
+        {
+            "name": "C++ function",
+            "scope": "meta.function.c,meta.function.cpp",
+            "settings": {
+                "foreground": "#179299"
+            }
+        },
+
+        {
+            "name": "C++ constructor/destructor",
+            "scope": [
+                "entity.name.function.definition.special.constructor",
+                "entity.name.function.definition.special.member.destructor"
+            ],
+            "settings": {
+                "foreground": "#7287fd"
+            }
+        },
+        {
+            "name": "C++ directive",
+            "scope": [
+                "keyword.control.directive",
+                "keyword.other.using.directive",
+                "punctuation.definition.directive"
+            ],
+            "settings": {
+                "foreground": "#179299",
+                "fontStyle": "italic"
+            }
+        },
+        {
+            "name": "C++ ifdef directive",
+            "scope": [
+                "keyword.control.directive.conditional.ifdef.cpp",
+                "keyword.control.directive.else.cpp",
+                "keyword.control.directive.else.cpp punctuation.definition.directive.cpp",
+                "keyword.control.directive.endif.cpp",
+                "keyword.control.directive.conditional.ifdef.cpp punctuation.definition.directive.cpp",
+                "keyword.control.directive.endif.cpp punctuation.definition.directive.cpp"
+            ],
+            "settings": {
+                "foreground": "#d20f39"
+            }
+        },
+        {
+            "name": "C++ misc",
+            "scope": [
+                "entity.name.other.preprocessor.macro.predefined.probably",
+                "entity.name.scope-resolution.cpp"
+            ],
+            "settings": {
+                "foreground": "#dc8a78",
+                "fontStyle": "italic"
+            }
+        },
+        {
+            "name": "C++ pointer/reference",
+            "scope": [
+                "storage.modifier.pointer.cpp",
+                "storage.modifier.reference.cpp"
+            ],
+            "settings": {
+                "foreground": "#179299"
+            }
+        },
+        {
+            "name": "C++ loop/conditional",
+            "scope": [
+                "keyword.control.for",
+                "keyword.control.while",
+                "keyword.control.if",
+                "keyword.control.else",
+                "keyword.control.switch",
+                "keyword.control.case"
+            ],
+            "settings": {
+                "foreground": "#8839ef",
+                "fontStyle": "bold"
+            }
+        },
+        {
+            "name": "C++ return",
+            "scope": "keyword.control.return",
+            "settings": {
+                "foreground": "#ea76cb"
+            }
+        },
+        {
+            "name": "C++ block",
+            "scope": [
+                "punctuation.section.block.begin.bracket.curly.cpp",
+                "punctuation.section.block.end.bracket.curly.cpp",
+                "punctuation.terminator.statement.c",
+                "punctuation.section.block.begin.bracket.curly.c",
+                "punctuation.section.block.end.bracket.curly.c",
+                "punctuation.section.parens.begin.bracket.round.c",
+                "punctuation.section.parens.end.bracket.round.c",
+                "punctuation.section.parameters.begin.bracket.round.c",
+                "punctuation.section.parameters.end.bracket.round.c"
+            ],
+            "settings": {
+                "foreground": "#4c4f69"
+            }
+        },
+        {
+            "name": "C++ storage type modifier",
+            "scope": "storage.type.built-in.primitive.cpp",
+            "settings": {
+                "foreground": "#df8e1d"
+            }
+        },
+        {
+            "name": "C++/C#",
+            "scope": [
+                "entity.name.label.cs",
+                "entity.name.scope-resolution.function.call",
+                "entity.name.scope-resolution.function.definition"
+            ],
+            "settings": {
+                "foreground": "#fe640b"
+            }
+        },
+        {
+            "name": "support.constant.edge",
+            "scope": "support.constant.edge",
+            "settings": {
+                "foreground": "#d20f39"
+            }
+        },
+        {
+            "name": "regexp constant character-class",
+            "scope": "constant.other.character-class.regexp",
+            "settings": {
+                "foreground": "#179299"
+            }
+        },
+        {
+            "name": "regexp operator.quantifier",
+            "scope": "keyword.operator.quantifier.regexp",
+            "settings": {
+                "foreground": "#df8e1d"
+            }
+        },
+        {
+            "name": "punctuation.definition",
+            "scope": "punctuation.definition.string.begin,punctuation.definition.string.end",
+            "settings": {
+                "foreground": "#40a02b"
+            }
+        },
+        {
+            "name": "Comment Markup Link",
+            "scope": "comment markup.link",
+            "settings": {
+                "foreground": "#9ca0b0"
+            }
+        },
+        {
+            "name": "markup diff",
+            "scope": "markup.changed.diff",
+            "settings": {
+                "foreground": "#fe640b"
+            }
+        },
+        {
+            "name": "diff",
+            "scope": "meta.diff.header.from-file,meta.diff.header.to-file,punctuation.definition.from-file.diff,punctuation.definition.to-file.diff",
+            "settings": {
+                "foreground": "#1e66f5"
+            }
+        },
+        {
+            "name": "inserted.diff",
+            "scope": "markup.inserted.diff",
+            "settings": {
+                "foreground": "#40a02b"
+            }
+        },
+        {
+            "name": "deleted.diff",
+            "scope": "markup.deleted.diff",
+            "settings": {
+                "foreground": "#179299"
+            }
+        },
+        {
+            "name": "Quote multi",
+            "scope": [
+                "string.quoted.docstring.multi",
+                "string.quoted.multi",
+                "source.python string.quoted.docstring.multi.python punctuation.definition.string.begin.python",
+                "source.python string.quoted.docstring.multi.python punctuation.definition.string.end.python",
+                "source.python string.quoted.multi.python punctuation.definition.string.begin.python",
+                "source.python string.quoted.multi.python punctuation.definition.string.end.python",
+                "markup.fenced_code.block"
+            ],
+            "settings": {
+                "foreground": "#179299",
+                "fontStyle": "italic"
+            }
+        },
+        {
+            "name": "js/ts punctuation separator key-value",
+            "scope": "punctuation.separator.key-value",
+            "settings": {
+                "foreground": "#4c4f69"
+            }
+        },
+        {
+            "name": "js/ts import keyword",
+            "scope": "keyword.operator.expression.import",
+            "settings": {
+                "foreground": "#1e66f5"
+            }
+        },
+        {
+            "name": "math js/ts",
+            "scope": "support.constant.math",
+            "settings": {
+                "foreground": "#fe640b"
+            }
+        },
+        {
+            "name": "math property js/ts",
+            "scope": "support.constant.property.math",
+            "settings": {
+                "foreground": "#df8e1d"
+            }
+        },
+        {
+            "name": "js/ts variable.other.constant",
+            "scope": "variable.other.constant",
+            "settings": {
+                "foreground": "#4c4f69"
+            }
+        },
+        {
+            "name": "java type",
+            "scope": [
+                "storage.type.annotation.java",
+                "storage.type.object.array.java"
+            ],
+            "settings": {
+                "foreground": "#fe640b"
+            }
+        },
+        {
+            "name": "java source",
+            "scope": "source.java",
+            "settings": {
+                "foreground": "#179299"
+            }
+        },
+        {
+            "name": "java modifier.import",
+            "scope": "punctuation.section.block.begin.java,punctuation.section.block.end.java,punctuation.definition.method-parameters.begin.java,punctuation.definition.method-parameters.end.java,meta.method.identifier.java,punctuation.section.method.begin.java,punctuation.section.method.end.java,punctuation.terminator.java,punctuation.section.class.begin.java,punctuation.section.class.end.java,punctuation.section.inner-class.begin.java,punctuation.section.inner-class.end.java,meta.method-call.java,punctuation.section.class.begin.bracket.curly.java,punctuation.section.class.end.bracket.curly.java,punctuation.section.method.begin.bracket.curly.java,punctuation.section.method.end.bracket.curly.java,punctuation.separator.period.java,punctuation.bracket.angle.java,punctuation.definition.annotation.java,meta.method.body.java",
+            "settings": {
+                "foreground": "#4c4f69"
+            }
+        },
+        {
+            "name": "java modifier.import",
+            "scope": "meta.method.java",
+            "settings": {
+                "foreground": "#1e66f5"
+            }
+        },
+        {
+            "name": "java modifier.import",
+            "scope": "storage.modifier.import.java,storage.type.java,storage.type.generic.java",
+            "settings": {
+                "foreground": "#fe640b"
+            }
+        },
+        {
+            "name": "java instanceof",
+            "scope": "keyword.operator.instanceof.java",
+            "settings": {
+                "foreground": "#d20f39"
+            }
+        },
+        {
+            "name": "java variable.name",
+            "scope": "meta.definition.variable.name.java",
+            "settings": {
+                "foreground": "#4c4f69"
+            }
+        },
+        {
+            "name": "operator logical",
+            "scope": [
+                "keyword.operator.logical",
+                "keyword.operator.ternary"
+            ],
+            "settings": {
+                "foreground": "#04a5e5",
+                "fontStyle": "bold"
+            }
+        },
+        {
+            "name": "operator bitwise",
+            "scope": "keyword.operator.bitwise",
+            "settings": {
+                "foreground": "#04a5e5"
+            }
+        },
+        {
+            "name": "operator channel",
+            "scope": "keyword.operator.channel",
+            "settings": {
+                "foreground": "#04a5e5"
+            }
+        },
+        {
+            "name": "support.constant.property-value.scss",
+            "scope": "support.constant.property-value.scss,support.constant.property-value.css",
+            "settings": {
+                "foreground": "#df8e1d"
+            }
+        },
+        {
+            "name": "CSS/SCSS/LESS Operators",
+            "scope": "keyword.operator.css,keyword.operator.scss,keyword.operator.less",
+            "settings": {
+                "foreground": "#04a5e5"
+            }
+        },
+        {
+            "name": "css color standard name",
+            "scope": "support.constant.color.w3c-standard-color-name.css,support.constant.color.w3c-standard-color-name.scss",
+            "settings": {
+                "foreground": "#df8e1d"
+            }
+        },
+        {
+            "name": "css comma",
+            "scope": "punctuation.separator.list.comma.css",
+            "settings": {
+                "foreground": "#4c4f69"
+            }
+        },
+        {
+            "name": "css attribute-name.id",
+            "scope": "support.constant.color.w3c-standard-color-name.css",
+            "settings": {
+                "foreground": "#df8e1d"
+            }
+        },
+        {
+            "name": "css property-name",
+            "scope": "support.type.vendored.property-name.css",
+            "settings": {
+                "foreground": "#04a5e5"
+            }
+        },
+        {
+            "name": "js/ts module",
+            "scope": "support.module.node,support.type.object.module,support.module.node",
+            "settings": {
+                "foreground": "#fe640b"
+            }
+        },
+        {
+            "name": "entity.name.type.module",
+            "scope": "entity.name.type.module",
+            "settings": {
+                "foreground": "#fe640b"
+            }
+        },
+        {
+            "name": "js variable readwrite",
+            "scope": "variable.other.readwrite,meta.object-literal.key,support.variable.property,support.variable.object.process,support.variable.object.node",
+            "settings": {
+                "foreground": "#4c4f69"
+            }
+        },
+        {
+            "name": "js/ts json",
+            "scope": "support.constant.json",
+            "settings": {
+                "foreground": "#df8e1d"
+            }
+        },
+        {
+            "name": "js/ts Keyword",
+            "scope": [
+                "keyword.operator.expression.instanceof",
+                "keyword.operator.new",
+                "keyword.operator.ternary",
+                "keyword.operator.optional",
+                "keyword.operator.expression.keyof"
+            ],
+            "settings": {
+                "foreground": "#d20f39"
+            }
+        },
+        {
+            "name": "js/ts console",
+            "scope": "support.type.object.console",
+            "settings": {
+                "foreground": "#179299"
+            }
+        },
+        {
+            "name": "js/ts support.variable.property.process",
+            "scope": "support.variable.property.process",
+            "settings": {
+                "foreground": "#df8e1d"
+            }
+        },
+        {
+            "name": "js console function",
+            "scope": "entity.name.function,support.function.console",
+            "settings": {
+                "foreground": "#1e66f5"
+            }
+        },
+        {
+            "name": "operator",
+            "scope": "keyword.operator.delete",
+            "settings": {
+                "foreground": "#d20f39"
+            }
+        },
+        {
+            "name": "js dom",
+            "scope": "support.type.object.dom",
+            "settings": {
+                "foreground": "#04a5e5"
+            }
+        },
+        {
+            "name": "js dom variable",
+            "scope": ["support.variable.dom", "support.variable.property.dom"],
+            "settings": {
+                "foreground": "#179299"
+            }
+        },
+        {
+            "name": "keyword.operator",
+            "scope": [
+                "keyword.operator.arithmetic",
+                "keyword.operator.comparison",
+                "keyword.operator.decrement",
+                "keyword.operator.increment",
+                "keyword.operator.relational"
+            ],
+            "settings": {
+                "foreground": "#04a5e5",
+                "fontStyle": "bold"
+            }
+        },
+        {
+            "name": "C operators",
+            "scope": [
+                "keyword.operator.c",
+                "keyword.operator.increment.c",
+                "keyword.operator.decrement.c",
+                "keyword.operator.bitwise.shift.c",
+                "keyword.operator.cpp",
+                "keyword.operator.increment.cpp",
+                "keyword.operator.decrement.cpp",
+                "keyword.operator.bitwise.shift.cpp"
+            ],
+            "settings": {
+                "foreground": "#04a5e5",
+                "fontStyle": "bold"
+            }
+        },
+        {
+            "name": "Punctuation",
+            "scope": "punctuation.separator.delimiter",
+            "settings": {
+                "foreground": "#4c4f69"
+            }
+        },
+        {
+            "name": "Other punctuation .c",
+            "scope": "punctuation.separator.c,punctuation.separator.cpp",
+            "settings": {
+                "foreground": "#d20f39"
+            }
+        },
+        {
+            "name": "C type posix-reserved",
+            "scope": "support.type.posix-reserved.c,support.type.posix-reserved.cpp",
+            "settings": {
+                "foreground": "#04a5e5"
+            }
+        },
+        {
+            "name": "keyword.operator.sizeof.c",
+            "scope": "keyword.operator.sizeof.c,keyword.operator.sizeof.cpp",
+            "settings": {
+                "foreground": "#d20f39"
+            }
+        },
+        {
+            "name": "python type",
+            "scope": "support.type.python",
+            "settings": {
+                "foreground": "#04a5e5"
+            }
+        },
+        {
+            "name": "python block",
+            "scope": "punctuation.definition.arguments.begin.python,punctuation.definition.arguments.end.python,punctuation.separator.arguments.python,punctuation.definition.list.begin.python,punctuation.definition.list.end.python",
+            "settings": {
+                "foreground": "#4c4f69"
+            }
+        },
+        {
+            "name": "python function-call.generic",
+            "scope": "meta.function-call.generic.python",
+            "settings": {
+                "foreground": "#1e66f5",
+                "fontStyle": "italic"
+            }
+        },
+        {
+            "name": "python placeholder reset to normal string",
+            "scope": "constant.character.format.placeholder.other.python",
+            "settings": {
+                "foreground": "#df8e1d"
+            }
+        },
+        {
+            "name": "Operators",
+            "scope": "keyword.operator",
+            "settings": {
+                "foreground": "#04a5e5",
+                "fontStyle": "bold"
+            }
+        },
+        {
+            "name": "Keywords",
+            "scope": "keyword",
+            "settings": {
+                "foreground": "#d20f39"
+            }
+        },
+        {
+            "name": "Namespaces",
+            "scope": "entity.name.namespace",
+            "settings": {
+                "foreground": "#fe640b"
+            }
+        },
+        {
+            "name": "Language variables",
+            "scope": "variable.language",
+            "settings": {
+                "foreground": "#fe640b"
+            }
+        },
+        {
+            "name": "Java Variables",
+            "scope": "token.variable.parameter.java",
+            "settings": {
+                "foreground": "#4c4f69"
+            }
+        },
+        {
+            "name": "Java Imports",
+            "scope": "import.storage.java",
+            "settings": {
+                "foreground": "#fe640b"
+            }
+        },
+        {
+            "name": "Packages",
+            "scope": "token.package.keyword",
+            "settings": {
+                "foreground": "#d20f39"
+            }
+        },
+        {
+            "name": "Packages",
+            "scope": "token.package",
+            "settings": {
+                "foreground": "#4c4f69"
+            }
+        },
+        {
+            "name": "Functions",
+            "scope": [
+                "entity.name.function",
+                "meta.require",
+                "support.function.any-method",
+                "variable.function"
+            ],
+            "settings": {
+                "foreground": "#1e66f5",
+                "fontStyle": "italic"
+            }
+        },
+        {
+            "name": "Classes",
+            "scope": "entity.name.type.namespace",
+            "settings": {
+                "foreground": "#fe640b"
+            }
+        },
+        {
+            "name": "Classes",
+            "scope": "support.class, entity.name.type.class",
+            "settings": {
+                "foreground": "#fe640b"
+            }
+        },
+        {
+            "name": "Class name",
+            "scope": "entity.name.class.identifier.namespace.type",
+            "settings": {
+                "foreground": "#fe640b"
+            }
+        },
+        {
+            "name": "Class name",
+            "scope": [
+                "entity.name.class",
+                "variable.other.class.js",
+                "variable.other.class.ts"
+            ],
+            "settings": {
+                "foreground": "#fe640b"
+            }
+        },
+        {
+            "name": "Class name php",
+            "scope": "variable.other.class.php",
+            "settings": {
+                "foreground": "#179299"
+            }
+        },
+        {
+            "name": "Type Name",
+            "scope": "entity.name.type",
+            "settings": {
+                "foreground": "#fe640b"
+            }
+        },
+        {
+            "name": "Keyword Control",
+            "scope": "keyword.control",
+            "settings": {
+                "foreground": "#d20f39"
+            }
+        },
+        {
+            "name": "Control Elements",
+            "scope": "control.elements, keyword.operator.less",
+            "settings": {
+                "foreground": "#df8e1d"
+            }
+        },
+        {
+            "name": "Methods",
+            "scope": "keyword.other.special-method",
+            "settings": {
+                "foreground": "#1e66f5"
+            }
+        },
+        {
+            "name": "Storage",
+            "scope": "storage",
+            "settings": {
+                "foreground": "#d20f39"
+            }
+        },
+        {
+            "name": "Storage JS TS",
+            "scope": "token.storage",
+            "settings": {
+                "foreground": "#d20f39"
+            }
+        },
+        {
+            "name": "Source Js Keyword Operator Delete,source Js Keyword Operator In,source Js Keyword Operator Of,source Js Keyword Operator Instanceof,source Js Keyword Operator New,source Js Keyword Operator Typeof,source Js Keyword Operator Void",
+            "scope": "keyword.operator.expression.delete,keyword.operator.expression.in,keyword.operator.expression.of,keyword.operator.expression.instanceof,keyword.operator.new,keyword.operator.expression.typeof,keyword.operator.expression.void",
+            "settings": {
+                "foreground": "#d20f39"
+            }
+        },
+        {
+            "name": "Java Storage",
+            "scope": "token.storage.type.java",
+            "settings": {
+                "foreground": "#fe640b"
+            }
+        },
+        {
+            "name": "Support",
+            "scope": "support.function",
+            "settings": {
+                "foreground": "#04a5e5"
+            }
+        },
+        {
+            "name": "Support type",
+            "scope": "support.type.property-name",
+            "settings": {
+                "foreground": "#4c4f69"
+            }
+        },
+        {
+            "name": "Support type",
+            "scope": "support.constant.property-value",
+            "settings": {
+                "foreground": "#4c4f69"
+            }
+        },
+        {
+            "name": "Support type",
+            "scope": "support.constant.font-name",
+            "settings": {
+                "foreground": "#df8e1d"
+            }
+        },
+        {
+            "name": "Meta tag",
+            "scope": "meta.tag",
+            "settings": {
+                "foreground": "#4c4f69"
+            }
+        },
+        {
+            "name": "Strings",
+            "scope": "string",
+            "settings": {
+                "foreground": "#40a02b"
+            }
+        },
+        {
+            "name": "Inherited Class",
+            "scope": "entity.other.inherited-class",
+            "settings": {
+                "foreground": "#fe640b"
+            }
+        },
+        {
+            "name": "Constant other symbol",
+            "scope": "constant.other.symbol",
+            "settings": {
+                "foreground": "#04a5e5"
+            }
+        },
+        {
+            "name": "Integers",
+            "scope": "constant.numeric",
+            "settings": {
+                "foreground": "#fe640b"
+            }
+        },
+        {
+            "name": "Constants",
+            "scope": "constant",
+            "settings": {
+                "foreground": "#df8e1d"
+            }
+        },
+        {
+            "name": "Constants",
+            "scope": "punctuation.definition.constant",
+            "settings": {
+                "foreground": "#df8e1d"
+            }
+        },
+        {
+            "name": "Tags",
+            "scope": "entity.name.tag",
+            "settings": {
+                "foreground": "#179299"
+            }
+        },
+        {
+            "name": "Attributes",
+            "scope": "entity.other.attribute-name",
+            "settings": {
+                "foreground": "#df8e1d"
+            }
+        },
+        {
+            "name": "Attribute IDs",
+            "scope": "entity.other.attribute-name.id",
+            "settings": {
+                "fontStyle": "",
+                "foreground": "#1e66f5"
+            }
+        },
+        {
+            "name": "Attribute class",
+            "scope": "entity.other.attribute-name.class.css",
+            "settings": {
+                "fontStyle": "",
+                "foreground": "#df8e1d"
+            }
+        },
+        {
+            "name": "Selector",
+            "scope": "meta.selector",
+            "settings": {
+                "foreground": "#d20f39"
+            }
+        },
+        {
+            "name": "Headings",
+            "scope": "markup.heading",
+            "settings": {
+                "foreground": "#179299"
+            }
+        },
+        {
+            "name": "Headings",
+            "scope": "markup.heading punctuation.definition.heading, entity.name.section",
+            "settings": {
+                "foreground": "#1e66f5"
+            }
+        },
+        {
+            "name": "Units",
+            "scope": "keyword.other.unit",
+            "settings": {
+                "foreground": "#179299"
+            }
+        },
+        {
+            "name": "Bold",
+            "scope": "markup.bold,todo.bold",
+            "settings": {
+                "foreground": "#df8e1d"
+            }
+        },
+        {
+            "name": "Bold",
+            "scope": "punctuation.definition.bold",
+            "settings": {
+                "foreground": "#fe640b"
+            }
+        },
+        {
+            "name": "markup Italic",
+            "scope": "markup.italic, punctuation.definition.italic,todo.emphasis",
+            "settings": {
+                "foreground": "#d20f39"
+            }
+        },
+        {
+            "name": "emphasis md",
+            "scope": "emphasis md",
+            "settings": {
+                "foreground": "#d20f39"
+            }
+        },
+        {
+            "name": "[VSCODE-CUSTOM] Markdown headings",
+            "scope": "entity.name.section.markdown",
+            "settings": {
+                "foreground": "#179299"
+            }
+        },
+        {
+            "name": "[VSCODE-CUSTOM] Markdown heading Punctuation Definition",
+            "scope": "punctuation.definition.heading.markdown",
+            "settings": {
+                "foreground": "#179299"
+            }
+        },
+        {
+            "name": "punctuation.definition.list.begin.markdown",
+            "scope": "punctuation.definition.list.begin.markdown",
+            "settings": {
+                "foreground": "#179299"
+            }
+        },
+        {
+            "name": "[VSCODE-CUSTOM] Markdown heading setext",
+            "scope": "markup.heading.setext",
+            "settings": {
+                "foreground": "#4c4f69"
+            }
+        },
+        {
+            "name": "[VSCODE-CUSTOM] Markdown Punctuation Definition Bold",
+            "scope": "punctuation.definition.bold.markdown",
+            "settings": {
+                "foreground": "#df8e1d"
+            }
+        },
+        {
+            "name": "[VSCODE-CUSTOM] Markdown Inline Raw",
+            "scope": "markup.inline.raw.markdown",
+            "settings": {
+                "foreground": "#40a02b"
+            }
+        },
+        {
+            "name": "[VSCODE-CUSTOM] Markdown Inline Raw",
+            "scope": "markup.inline.raw.string.markdown",
+            "settings": {
+                "foreground": "#40a02b"
+            }
+        },
+        {
+            "name": "[VSCODE-CUSTOM] Markdown List Punctuation Definition",
+            "scope": "punctuation.definition.list.markdown",
+            "settings": {
+                "foreground": "#179299"
+            }
+        },
+        {
+            "name": "[VSCODE-CUSTOM] Markdown Punctuation Definition String",
+            "scope": [
+                "punctuation.definition.string.begin.markdown",
+                "punctuation.definition.string.end.markdown",
+                "punctuation.definition.metadata.markdown"
+            ],
+            "settings": {
+                "foreground": "#179299"
+            }
+        },
+        {
+            "name": "beginning.punctuation.definition.list.markdown",
+            "scope": ["beginning.punctuation.definition.list.markdown"],
+            "settings": {
+                "foreground": "#179299"
+            }
+        },
+        {
+            "name": "[VSCODE-CUSTOM] Markdown Punctuation Definition Link",
+            "scope": "punctuation.definition.metadata.markdown",
+            "settings": {
+                "foreground": "#179299"
+            }
+        },
+        {
+            "name": "[VSCODE-CUSTOM] Markdown Underline Link/Image",
+            "scope": "markup.underline.link.markdown,markup.underline.link.image.markdown",
+            "settings": {
+                "foreground": "#d20f39"
+            }
+        },
+        {
+            "name": "[VSCODE-CUSTOM] Markdown Link Title/Description",
+            "scope": "string.other.link.title.markdown,string.other.link.description.markdown",
+            "settings": {
+                "foreground": "#1e66f5"
+            }
+        },
+        {
+            "name": "Regular Expressions",
+            "scope": "string.regexp",
+            "settings": {
+                "foreground": "#04a5e5"
+            }
+        },
+        {
+            "name": "Escape Characters",
+            "scope": "constant.character.escape",
+            "settings": {
+                "foreground": "#04a5e5"
+            }
+        },
+        {
+            "name": "Embedded",
+            "scope": "punctuation.section.embedded, variable.interpolation",
+            "settings": {
+                "foreground": "#179299"
+            }
+        },
+        {
+            "name": "Embedded",
+            "scope": "punctuation.section.embedded.begin,punctuation.section.embedded.end",
+            "settings": {
+                "foreground": "#d20f39"
+            }
+        },
+        {
+            "name": "illegal",
+            "scope": "invalid.illegal",
+            "settings": {
+                "foreground": "#ffffff"
+            }
+        },
+        {
+            "name": "illegal",
+            "scope": "invalid.illegal.bad-ampersand.html",
+            "settings": {
+                "foreground": "#4c4f69"
+            }
+        },
+        {
+            "name": "Broken",
+            "scope": "invalid.broken",
+            "settings": {
+                "foreground": "#ffffff"
+            }
+        },
+        {
+            "name": "Deprecated",
+            "scope": "invalid.deprecated",
+            "settings": {
+                "foreground": "#ffffff"
+            }
+        },
+        {
+            "name": "Unimplemented",
+            "scope": "invalid.unimplemented",
+            "settings": {
+                "foreground": "#ffffff"
+            }
+        },
+        {
+            "name": "laravel blade tag",
+            "scope": "text.html.laravel-blade source.php.embedded.line.html entity.name.tag.laravel-blade",
+            "settings": {
+                "foreground": "#d20f39"
+            }
+        },
+        {
+            "name": "laravel blade @",
+            "scope": "text.html.laravel-blade source.php.embedded.line.html support.constant.laravel-blade",
+            "settings": {
+                "foreground": "#d20f39"
+            }
+        },
+        {
+            "name": "use statement for other classes",
+            "scope": "support.other.namespace.use.php,support.other.namespace.use-as.php,support.other.namespace.php,entity.other.alias.php,meta.interface.php",
+            "settings": {
+                "foreground": "#fe640b"
+            }
+        },
+        {
+            "name": "error suppression",
+            "scope": "keyword.operator.error-control.php",
+            "settings": {
+                "foreground": "#d20f39"
+            }
+        },
+        {
+            "name": "php instanceof",
+            "scope": "keyword.operator.type.php",
+            "settings": {
+                "foreground": "#d20f39"
+            }
+        },
+        {
+            "name": "style double quoted array index normal begin",
+            "scope": "punctuation.section.array.begin.php",
+            "settings": {
+                "foreground": "#4c4f69"
+            }
+        },
+        {
+            "name": "style double quoted array index normal end",
+            "scope": "punctuation.section.array.end.php",
+            "settings": {
+                "foreground": "#4c4f69"
+            }
+        },
+        {
+            "name": "php illegal.non-null-typehinted",
+            "scope": "invalid.illegal.non-null-typehinted.php",
+            "settings": {
+                "foreground": "#f44747"
+            }
+        },
+        {
+            "name": "php types",
+            "scope": "storage.type.php,meta.other.type.phpdoc.php,keyword.other.type.php,keyword.other.array.phpdoc.php",
+            "settings": {
+                "foreground": "#fe640b"
+            }
+        },
+        {
+            "name": "php call-function",
+            "scope": "meta.function-call.php,meta.function-call.object.php,meta.function-call.static.php",
+            "settings": {
+                "foreground": "#1e66f5"
+            }
+        },
+        {
+            "name": "php function-resets",
+            "scope": "punctuation.definition.parameters.begin.bracket.round.php,punctuation.definition.parameters.end.bracket.round.php,punctuation.separator.delimiter.php,punctuation.section.scope.begin.php,punctuation.section.scope.end.php,punctuation.terminator.expression.php,punctuation.definition.arguments.begin.bracket.round.php,punctuation.definition.arguments.end.bracket.round.php,punctuation.definition.storage-type.begin.bracket.round.php,punctuation.definition.storage-type.end.bracket.round.php,punctuation.definition.array.begin.bracket.round.php,punctuation.definition.array.end.bracket.round.php,punctuation.definition.begin.bracket.round.php,punctuation.definition.end.bracket.round.php,punctuation.definition.begin.bracket.curly.php,punctuation.definition.end.bracket.curly.php,punctuation.definition.section.switch-block.end.bracket.curly.php,punctuation.definition.section.switch-block.start.bracket.curly.php,punctuation.definition.section.switch-block.begin.bracket.curly.php,punctuation.definition.section.switch-block.end.bracket.curly.php",
+            "settings": {
+                "foreground": "#4c4f69"
+            }
+        },
+        {
+            "name": "support php constants",
+            "scope": "support.constant.ext.php,support.constant.std.php,support.constant.core.php,support.constant.parser-token.php",
+            "settings": {
+                "foreground": "#df8e1d"
+            }
+        },
+        {
+            "name": "php goto",
+            "scope": "entity.name.goto-label.php,support.other.php",
+            "settings": {
+                "foreground": "#1e66f5"
+            }
+        },
+        {
+            "name": "php logical/bitwise operator",
+            "scope": "keyword.operator.logical.php,keyword.operator.bitwise.php,keyword.operator.arithmetic.php",
+            "settings": {
+                "foreground": "#04a5e5"
+            }
+        },
+        {
+            "name": "php regexp operator",
+            "scope": "keyword.operator.regexp.php",
+            "settings": {
+                "foreground": "#d20f39"
+            }
+        },
+        {
+            "name": "php comparison",
+            "scope": "keyword.operator.comparison.php",
+            "settings": {
+                "foreground": "#04a5e5"
+            }
+        },
+        {
+            "name": "php heredoc/nowdoc",
+            "scope": "keyword.operator.heredoc.php,keyword.operator.nowdoc.php",
+            "settings": {
+                "foreground": "#d20f39"
+            }
+        },
+        {
+            "name": "python function decorator @",
+            "scope": "meta.function.decorator.python",
+            "settings": {
+                "foreground": "#1e66f5"
+            }
+        },
+        {
+            "name": "python function support",
+            "scope": "support.token.decorator.python,meta.function.decorator.identifier.python",
+            "settings": {
+                "foreground": "#04a5e5"
+            }
+        },
+        {
+            "name": "parameter function js/ts",
+            "scope": "function.parameter",
+            "settings": {
+                "foreground": "#4c4f69"
+            }
+        },
+        {
+            "name": "brace function",
+            "scope": "function.brace",
+            "settings": {
+                "foreground": "#4c4f69"
+            }
+        },
+        {
+            "name": "parameter function ruby cs",
+            "scope": "function.parameter.ruby, function.parameter.cs",
+            "settings": {
+                "foreground": "#4c4f69"
+            }
+        },
+        {
+            "name": "constant.language.symbol.ruby",
+            "scope": "constant.language.symbol.ruby",
+            "settings": {
+                "foreground": "#04a5e5"
+            }
+        },
+        {
+            "name": "rgb-value",
+            "scope": "rgb-value",
+            "settings": {
+                "foreground": "#04a5e5"
+            }
+        },
+        {
+            "name": "rgb value",
+            "scope": "inline-color-decoration rgb-value",
+            "settings": {
+                "foreground": "#df8e1d"
+            }
+        },
+        {
+            "name": "rgb value less",
+            "scope": "less rgb-value",
+            "settings": {
+                "foreground": "#df8e1d"
+            }
+        },
+        {
+            "name": "sass selector",
+            "scope": "selector.sass",
+            "settings": {
+                "foreground": "#179299"
+            }
+        },
+        {
+            "name": "ts primitive/builtin types",
+            "scope": "support.type.primitive.ts,support.type.builtin.ts,support.type.primitive.tsx,support.type.builtin.tsx",
+            "settings": {
+                "foreground": "#fe640b"
+            }
+        },
+        {
+            "name": "block scope",
+            "scope": "block.scope.end,block.scope.begin",
+            "settings": {
+                "foreground": "#4c4f69"
+            }
+        },
+        {
+            "name": "cs storage type",
+            "scope": "storage.type.cs",
+            "settings": {
+                "foreground": "#fe640b"
+            }
+        },
+        {
+            "name": "cs local variable",
+            "scope": "entity.name.variable.local.cs",
+            "settings": {
+                "foreground": "#4c4f69"
+            }
+        },
+        {
+            "scope": "token.info-token",
+            "settings": {
+                "foreground": "#1e66f5"
+            }
+        },
+        {
+            "scope": "token.warn-token",
+            "settings": {
+                "foreground": "#df8e1d"
+            }
+        },
+        {
+            "scope": "token.error-token",
+            "settings": {
+                "foreground": "#f44747"
+            }
+        },
+        {
+            "scope": "token.debug-token",
+            "settings": {
+                "foreground": "#d20f39"
+            }
+        },
+        {
+            "name": "String interpolation",
+            "scope": [
+                "punctuation.definition.template-expression.begin",
+                "punctuation.definition.template-expression.end",
+                "punctuation.section.embedded"
+            ],
+            "settings": {
+                "foreground": "#d20f39"
+            }
+        },
+        {
+            "name": "Reset JavaScript string interpolation expression",
+            "scope": ["meta.template.expression"],
+            "settings": {
+                "foreground": "#4c4f69"
+            }
+        },
+        {
+            "name": "Import module JS",
+            "scope": ["keyword.operator.module"],
+            "settings": {
+                "foreground": "#d20f39"
+            }
+        },
+        {
+            "name": "js Flowtype",
+            "scope": ["support.type.type.flowtype"],
+            "settings": {
+                "foreground": "#1e66f5"
+            }
+        },
+        {
+            "name": "js Flow",
+            "scope": ["support.type.primitive"],
+            "settings": {
+                "foreground": "#fe640b"
+            }
+        },
+        {
+            "name": "js class prop",
+            "scope": ["meta.property.object"],
+            "settings": {
+                "foreground": "#179299"
+            }
+        },
+        {
+            "name": "js func parameter",
+            "scope": ["variable.parameter.function.js"],
+            "settings": {
+                "foreground": "#179299"
+            }
+        },
+        {
+            "name": "js template literals begin",
+            "scope": ["keyword.other.template.begin"],
+            "settings": {
+                "foreground": "#40a02b"
+            }
+        },
+        {
+            "name": "js template literals end",
+            "scope": ["keyword.other.template.end"],
+            "settings": {
+                "foreground": "#40a02b"
+            }
+        },
+        {
+            "name": "js template literals variable braces begin",
+            "scope": ["keyword.other.substitution.begin"],
+            "settings": {
+                "foreground": "#40a02b"
+            }
+        },
+        {
+            "name": "js template literals variable braces end",
+            "scope": ["keyword.other.substitution.end"],
+            "settings": {
+                "foreground": "#40a02b"
+            }
+        },
+        {
+            "name": "go operator",
+            "scope": [
+                "keyword.operator.arithmetic.go",
+                "keyword.operator.address.go"
+            ],
+            "settings": {
+                "foreground": "#d20f39"
+            }
+        },
+        {
+            "name": "Go package name",
+            "scope": ["entity.name.package.go"],
+            "settings": {
+                "foreground": "#fe640b"
+            }
+        },
+        {
+            "name": "elm prelude",
+            "scope": ["support.type.prelude.elm"],
+            "settings": {
+                "foreground": "#04a5e5"
+            }
+        },
+        {
+            "name": "elm constant",
+            "scope": ["support.constant.elm"],
+            "settings": {
+                "foreground": "#df8e1d"
+            }
+        },
+        {
+            "name": "template literal",
+            "scope": ["punctuation.quasi.element"],
+            "settings": {
+                "foreground": "#d20f39"
+            }
+        },
+        {
+            "name": "html/pug (jade) escaped characters and entities",
+            "scope": ["constant.character.entity"],
+            "settings": {
+                "foreground": "#179299"
+            }
+        },
+        {
+            "name": "styling css pseudo-elements/classes to be able to differentiate from classes which are the same colour",
+            "scope": [
+                "entity.other.attribute-name.pseudo-element",
+                "entity.other.attribute-name.pseudo-class"
+            ],
+            "settings": {
+                "foreground": "#04a5e5"
+            }
+        },
+        {
+            "name": "Clojure globals",
+            "scope": ["entity.global.clojure"],
+            "settings": {
+                "foreground": "#fe640b"
+            }
+        },
+        {
+            "name": "Clojure symbols",
+            "scope": ["meta.symbol.clojure"],
+            "settings": {
+                "foreground": "#179299"
+            }
+        },
+        {
+            "name": "Clojure constants",
+            "scope": ["constant.keyword.clojure"],
+            "settings": {
+                "foreground": "#04a5e5"
+            }
+        },
+        {
+            "name": "CoffeeScript Function Argument",
+            "scope": [
+                "meta.arguments.coffee",
+                "variable.parameter.function.coffee"
+            ],
+            "settings": {
+                "foreground": "#179299"
+            }
+        },
+        {
+            "name": "Ini Default Text",
+            "scope": ["source.ini"],
+            "settings": {
+                "foreground": "#40a02b"
+            }
+        },
+
+        {
+            "name": "Shell definition variables",
+            "scope": ["punctuation.definition.variable.shell"],
+            "settings": {
+                "foreground": "#8c8fa1"
+            }
+        },
+        {
+            "name": "Shell logical operators",
+            "scope": ["keyword.operator.logical.shell"],
+            "settings": {
+                "foreground": "#04a5e5"
+            }
+        },
+        {
+            "name": "Shell clauses",
+            "scope": ["meta.scope.case-clause-body.shell"],
+            "settings": {
+                "foreground": "#4c4f69"
+            }
+        },
+        {
+            "name": "Shell funcs",
+            "scope": ["meta.scope.group.shell"],
+            "settings": {
+                "foreground": "#1e66f5"
+            }
+        },
+        {
+            "name": "Shell interpolated cmds",
+            "scope": ["string.interpolated.dollar.shell"],
+            "settings": {
+                "foreground": "#df8e1d"
+            }
+        },
+        {
+            "name": "Shell interpolated strings",
+            "scope": ["string.quoted.single.shell"],
+            "settings": {
+                "foreground": "#7287fd"
+            }
+        },
+        {
+            "name": "Shell pipe symbol",
+            "scope": ["keyword.operator.pipe.shell"],
+            "settings": {
+                "foreground": "#04a5e5"
+            }
+        },
+        {
+            "name": "Shell group definition",
+            "scope": ["punctuation.definition.group.shell"],
+            "settings": {
+                "foreground": "#8c8fa1"
+            }
+        },
+        {
+            "name": "Shell conditionals",
+            "scope": ["keyword.control.shell"],
+            "settings": {
+                "foreground": "#8839ef"
+            }
+        },
+        {
+            "name": "Shell opeartors and punct delimeters",
+            "scope": ["keyword.operator.list.shell"],
+            "settings": {
+                "foreground": "#179299"
+            }
+        },
+        {
+            "name": "Shell parenthesis",
+            "scope": ["punctuation.definition.logical-expression.shell"],
+            "settings": {
+                "foreground": "#8c8fa1"
+            }
+        },
+
+        {
+            "name": "Makefile prerequisities",
+            "scope": ["meta.scope.prerequisites.makefile"],
+            "settings": {
+                "foreground": "#179299"
+            }
+        },
+        {
+            "name": "Makefile text colour",
+            "scope": ["source.makefile"],
+            "settings": {
+                "foreground": "#fe640b"
+            }
+        },
+        {
+            "name": "Groovy import names",
+            "scope": ["storage.modifier.import.groovy"],
+            "settings": {
+                "foreground": "#fe640b"
+            }
+        },
+        {
+            "name": "Groovy Methods",
+            "scope": ["meta.method.groovy"],
+            "settings": {
+                "foreground": "#1e66f5"
+            }
+        },
+        {
+            "name": "Groovy Variables",
+            "scope": ["meta.definition.variable.name.groovy"],
+            "settings": {
+                "foreground": "#179299"
+            }
+        },
+        {
+            "name": "Groovy Inheritance",
+            "scope": ["meta.definition.class.inherited.classes.groovy"],
+            "settings": {
+                "foreground": "#40a02b"
+            }
+        },
+        {
+            "name": "HLSL Semantic",
+            "scope": ["support.variable.semantic.hlsl"],
+            "settings": {
+                "foreground": "#fe640b"
+            }
+        },
+        {
+            "name": "HLSL Types",
+            "scope": [
+                "support.type.texture.hlsl",
+                "support.type.sampler.hlsl",
+                "support.type.object.hlsl",
+                "support.type.object.rw.hlsl",
+                "support.type.fx.hlsl",
+                "support.type.object.hlsl"
+            ],
+            "settings": {
+                "foreground": "#d20f39"
+            }
+        },
+        {
+            "name": "SQL Variables",
+            "scope": ["text.variable", "text.bracketed"],
+            "settings": {
+                "foreground": "#179299"
+            }
+        },
+        {
+            "name": "types",
+            "scope": ["support.type.swift", "support.type.vb.asp"],
+            "settings": {
+                "foreground": "#fe640b"
+            }
+        },
+        {
+            "name": "heading 1, keyword",
+            "scope": ["entity.name.function.xi"],
+            "settings": {
+                "foreground": "#1e66f5"
+            }
+        },
+        {
+            "name": "heading 2, callable",
+            "scope": ["entity.name.class.xi"],
+            "settings": {
+                "foreground": "#04a5e5"
+            }
+        },
+        {
+            "name": "heading 3, property",
+            "scope": ["constant.character.character-class.regexp.xi"],
+            "settings": {
+                "foreground": "#179299"
+            }
+        },
+        {
+            "name": "heading 4, type, class, interface",
+            "scope": ["constant.regexp.xi"],
+            "settings": {
+                "foreground": "#d20f39"
+            }
+        },
+        {
+            "name": "heading 5, enums, preprocessor, constant, decorator",
+            "scope": ["keyword.control.xi"],
+            "settings": {
+                "foreground": "#04a5e5"
+            }
+        },
+        {
+            "name": "heading 6, number",
+            "scope": ["invalid.xi"],
+            "settings": {
+                "foreground": "#4c4f69"
+            }
+        },
+        {
+            "name": "string",
+            "scope": ["beginning.punctuation.definition.quote.markdown.xi"],
+            "settings": {
+                "foreground": "#40a02b"
+            }
+        },
+        {
+            "name": "comments",
+            "scope": ["beginning.punctuation.definition.list.markdown.xi"],
+            "settings": {
+                "foreground": "#9ca0b0"
+            }
+        },
+        {
+            "name": "link",
+            "scope": ["constant.character.xi"],
+            "settings": {
+                "foreground": "#1e66f5"
+            }
+        },
+        {
+            "name": "accent",
+            "scope": ["accent.xi"],
+            "settings": {
+                "foreground": "#1e66f5"
+            }
+        },
+        {
+            "name": "wikiword",
+            "scope": ["wikiword.xi"],
+            "settings": {
+                "foreground": "#df8e1d"
+            }
+        },
+        {
+            "name": "language operators like '+', '-' etc",
+            "scope": ["constant.other.color.rgb-value.xi"],
+            "settings": {
+                "foreground": "#ffffff"
+            }
+        },
+        {
+            "name": "elements to dim",
+            "scope": ["punctuation.definition.tag.xi"],
+            "settings": {
+                "foreground": "#9ca0b0"
+            }
+        },
+        {
+            "name": "Markdown underscore-style headers",
+            "scope": [
+                "entity.name.label.cs",
+                "markup.heading.setext.1.markdown",
+                "markup.heading.setext.2.markdown"
+            ],
+            "settings": {
+                "foreground": "#179299"
+            }
+        },
+        {
+            "name": "meta.brace.square",
+            "scope": [" meta.brace.square"],
+            "settings": {
+                "foreground": "#4c4f69"
+            }
+        },
+        {
+            "name": "Comments",
+            "scope": "comment, punctuation.definition.comment",
+            "settings": {
+                "fontStyle": "italic",
+                "foreground": "#9ca0b0"
+            }
+        },
+        {
+            "name": "[VSCODE-CUSTOM] Markdown Quote",
+            "scope": "markup.quote.markdown",
+            "settings": {
+                "foreground": "#9ca0b0"
+            }
+        },
+        {
+            "name": "punctuation.definition.block.sequence.item.yaml",
+            "scope": "punctuation.definition.block.sequence.item.yaml",
+            "settings": {
+                "foreground": "#4c4f69"
+            }
+        },
+        {
+            "scope": ["constant.language.symbol.elixir"],
+            "settings": {
+                "foreground": "#04a5e5"
+            }
+        },
+        {
+            "name": "js/ts italic",
+            "scope": "entity.other.attribute-name.js,entity.other.attribute-name.ts,entity.other.attribute-name.jsx,entity.other.attribute-name.tsx,variable.parameter,variable.language.super",
+            "settings": {
+                "fontStyle": "italic"
+            }
+        },
+        {
+            "name": "comment",
+            "scope": "comment.line.double-slash,comment.block.documentation",
+            "settings": {
+                "fontStyle": "italic"
+            }
+        },
+        {
+            "name": "python keyword import",
+            "scope": "keyword.control.import.python",
+            "settings": {
+                "foreground": "#179299",
+                "fontStyle": "italic"
+            }
+        },
+        {
+            "name": "python keyword flow",
+            "scope": "keyword.control.flow.python",
+            "settings": {
+                "foreground": "#8839ef",
+                "fontStyle": "bold"
+            }
+        },
+        {
+            "name": "python storage type",
+            "scope": "storage.type.function.python",
+            "settings": {
+                "foreground": "#e64553",
+                "fontStyle": "italic"
+            }
+        },
+        {
+            "name": "markup.italic.markdown",
+            "scope": "markup.italic.markdown",
+            "settings": {
+                "fontStyle": "italic"
+            }
+        }
+    ],
+    "colors": {
+        "foreground": "#4c4f69",
+        "focusBorder": "#1e66f5",
+        "selection.background": "#9ca0b0",
+        "scrollbar.shadow": "#eff1f5",
+        "activityBar.foreground": "#4c4f69",
+        "activityBar.background": "#eff1f5",
+        "activityBar.inactiveForeground": "#4c4f695a",
+        "activityBarBadge.foreground": "#eff1f5",
+        "activityBarBadge.background": "#1e66f5",
+        "sideBar.background": "#e6e9ef",
+        "sideBar.foreground": "#4c4f69",
+        "sideBarSectionHeader.background": "#00000000",
+        "sideBarSectionHeader.foreground": "#4c4f69",
+        "sideBarTitle.foreground": "#4c4f69",
+        "list.inactiveSelectionBackground": "#eff1f5",
+        "list.inactiveSelectionForeground": "#4c4f69",
+        "list.hoverBackground": "#eff1f5",
+        "list.hoverForeground": "#4c4f69",
+        "list.activeSelectionBackground": "#acb0be",
+        "list.activeSelectionForeground": "#4c4f69",
+        "tree.indentGuidesStroke": "#9ca0b0",
+        "list.dropBackground": "#eff1f5",
+        "list.highlightForeground": "#1e66f5",
+        "list.focusBackground": "#bcc0cc",
+        "list.focusForeground": "#4c4f69",
+        "listFilterWidget.background": "#bcc0cc",
+        "listFilterWidget.outline": "#00000000",
+        "listFilterWidget.noMatchesOutline": "#d20f39",
+        "statusBar.foreground": "#4c4f69",
+        "statusBar.background": "#bcc0cc",
+        "statusBarItem.hoverBackground": "#ffffff1f",
+        "statusBar.debuggingBackground": "#d20f39",
+        "statusBar.debuggingForeground": "#bcc0cc",
+        "statusBar.noFolderBackground": "#8839ef",
+        "statusBar.noFolderForeground": "#bcc0cc",
+        "statusBarItem.remoteBackground": "#40a02b",
+        "statusBarItem.remoteForeground": "#bcc0cc",
+        "titleBar.activeBackground": "#eff1f5",
+        "titleBar.activeForeground": "#4c4f69",
+        "titleBar.inactiveBackground": "#eff1f591",
+        "titleBar.inactiveForeground": "#4c4f6980",
+        "titleBar.border": "#00000000",
+        "menubar.selectionForeground": "#4c4f69",
+        "menubar.selectionBackground": "#bcc0cc",
+        "menu.foreground": "#4c4f69",
+        "menu.background": "#bcc0cc",
+        "menu.selectionForeground": "#4c4f69",
+        "menu.selectionBackground": "#acb0be",
+        "menu.selectionBorder": "#00000000",
+        "menu.separatorBackground": "#4c4f69",
+        "menu.border": "#00000085",
+        "button.background": "#acb0be",
+        "button.foreground": "#4c4f69",
+        "button.hoverBackground": "#bcc0cc",
+        "button.secondaryForeground": "#4c4f69",
+        "button.secondaryBackground": "#bcc0cc",
+        "button.secondaryHoverBackground": "#eff1f5",
+        "input.background": "#eff1f5",
+        "input.border": "#00000000",
+        "input.foreground": "#4c4f69",
+        "inputOption.activeBackground": "#1e66f526",
+        "inputOption.activeBorder": "#1e66f500",
+        "inputOption.activeForeground": "#4c4f69",
+        "input.placeholderForeground": "#4c4f6970",
+        "textLink.foreground": "#1e66f5",
+        "editor.background": "#eff1f5",
+        "editor.foreground": "#4c4f69",
+        "editorLineNumber.foreground": "#8c8fa1",
+        "editorCursor.foreground": "#dc8a78",
+        "editorCursor.background": "#eff1f5",
+        "editor.selectionBackground": "#acb0be",
+        "editor.inactiveSelectionBackground": "#FFFFFF20",
+        "editorWhitespace.foreground": "#7c7f9318",
+        "editor.selectionHighlightBackground": "#7c7f935e",
+        "editor.selectionHighlightBorder": "#04a5e530",
+        "editor.findMatchBackground": "#acb0be",
+        "editor.findMatchBorder": "#1e66f56a",
+        "editor.findMatchHighlightBackground": "#fe640b5e",
+        "editor.findMatchHighlightBorder": "#ffffff00",
+        "editor.findRangeHighlightBackground": "#acb0be48",
+        "editor.findRangeHighlightBorder": "#ffffff00",
+        "editor.rangeHighlightBackground": "#1e66f53c",
+        "editor.rangeHighlightBorder": "#ffffff00",
+        "editor.hoverHighlightBackground": "#1e66f53c",
+        "editor.wordHighlightStrongBackground": "#acb0be",
+        "editor.wordHighlightBackground": "#575757b8",
+        "editor.lineHighlightBackground": "#ffffff0A",
+        "editor.lineHighlightBorder": "#eff1f5",
+        "editorLineNumber.activeForeground": "#40a02b",
+        "editorLink.activeForeground": "#1e66f5",
+        "editorIndentGuide.background": "#bcc0cc",
+        "editorIndentGuide.activeBackground": "#acb0be",
+        "editorRuler.foreground": "#acb0be",
+        "editorBracketMatch.background": "#7c7f9314",
+        "editorBracketMatch.border": "#7c7f93",
+        "editor.foldBackground": "#1e66f542",
+        "editorOverviewRuler.background": "#25252500",
+        "editorOverviewRuler.border": "#FFFFFF0F",
+        "editorError.foreground": "#d20f39",
+        "editorError.background": "#B73A3400",
+        "editorError.border": "#ffffff00",
+        "editorWarning.foreground": "#df8e1d",
+        "editorWarning.background": "#A9904000",
+        "editorWarning.border": "#ffffff00",
+        "editorInfo.foreground": "#1e66f5",
+        "editorInfo.background": "#4490BF00",
+        "editorInfo.border": "#4490BF00",
+        "editorGutter.background": "#eff1f5",
+        "editorGutter.modifiedBackground": "#04a5e5",
+        "editorGutter.addedBackground": "#40a02b",
+        "editorGutter.deletedBackground": "#d20f39",
+        "editorGutter.foldingControlForeground": "#7c7f93",
+        "editorCodeLens.foreground": "#8c8fa1",
+        "editorGroup.border": "#acb0be",
+        // test
+        "diffEditor.insertedTextBackground": "#40a02b18",
+        "diffEditor.removedTextBackground": "#d20f391c",
+        "diffEditor.border": "#acb0be",
+        "panel.background": "#eff1f5",
+        "panel.border": "#acb0be",
+        "panelTitle.activeBorder": "#4c4f69",
+        "panelTitle.activeForeground": "#4c4f69",
+        "panelTitle.inactiveForeground": "#4c4f69ad",
+        "badge.background": "#bcc0cc",
+        "badge.foreground": "#4c4f69",
+        "terminal.foreground": "#4c4f69",
+        "terminal.selectionBackground": "#acb0be34",
+        "terminalCursor.background": "#eff1f5",
+        "terminalCursor.foreground": "#dc8a78",
+        "terminal.border": "#acb0be",
+        "terminal.ansiBlack": "#9ca0b0",
+        "terminal.ansiBlue": "#1e66f5",
+        "terminal.ansiBrightBlack": "#8c8fa1",
+        "terminal.ansiBrightBlue": "#1e66f5",
+        "terminal.ansiBrightCyan": "#04a5e5",
+        "terminal.ansiBrightGreen": "#40a02b",
+        "terminal.ansiBrightMagenta": "#ea76cb",
+        "terminal.ansiBrightRed": "#d20f39",
+        "terminal.ansiBrightWhite": "#4c4f69",
+        "terminal.ansiBrightYellow": "#df8e1d",
+        "terminal.ansiCyan": "#04a5e5",
+        "terminal.ansiGreen": "#40a02b",
+        "terminal.ansiMagenta": "#ea76cb",
+        "terminal.ansiRed": "#d20f39",
+        "terminal.ansiWhite": "#7c7f93",
+        "terminal.ansiYellow": "#df8e1d",
+        "breadcrumb.background": "#eff1f5",
+        "breadcrumb.foreground": "#4c4f69cd",
+        "breadcrumb.focusForeground": "#4c4f69",
+        "editorGroupHeader.tabsBackground": "#eff1f5",
+        "tab.activeForeground": "#4c4f69",
+        "tab.border": "#bcc0cc",
+        "tab.activeBackground": "#eff1f5",
+        "tab.activeBorder": "#00000000",
+        "tab.activeBorderTop": "#00000000",
+        "tab.inactiveBackground": "#bcc0cc",
+        "tab.inactiveForeground": "#4c4f6964",
+        "scrollbarSlider.background": "#acb0be7e",
+        "scrollbarSlider.hoverBackground": "#9ca0b0",
+        "scrollbarSlider.activeBackground": "#bfbfbf66",
+        "progressBar.background": "#1e66f5",
+        "widget.shadow": "#00000080",
+        "editorWidget.foreground": "#4c4f69",
+        "editorWidget.background": "#eff1f5",
+        "editorWidget.resizeBorder": "#acb0be",
+        "pickerGroup.border": "#1e66f5",
+        "pickerGroup.foreground": "#1e66f5",
+        "debugToolBar.background": "#bcc0cc",
+        "debugToolBar.border": "#acb0be",
+        "notifications.foreground": "#4c4f69",
+        "notifications.background": "#bcc0cc",
+        "notificationToast.border": "#acb0be",
+        "notificationsErrorIcon.foreground": "#d20f39",
+        "notificationsWarningIcon.foreground": "#df8e1d",
+        "notificationsInfoIcon.foreground": "#1e66f5",
+        "notificationCenter.border": "#acb0be",
+        "notificationCenterHeader.foreground": "#4c4f69",
+        "notificationCenterHeader.background": "#eff1f5",
+        "notifications.border": "#bcc0cc",
+        "gitDecoration.addedResourceForeground": "#40a02b",
+        "gitDecoration.conflictingResourceForeground": "#8839ef",
+        "gitDecoration.deletedResourceForeground": "#d20f39",
+        "gitDecoration.ignoredResourceForeground": "#9ca0b0",
+        "gitDecoration.modifiedResourceForeground": "#df8e1d",
+        "gitDecoration.stageDeletedResourceForeground": "#d20f39",
+        "gitDecoration.stageModifiedResourceForeground": "#df8e1d",
+        "gitDecoration.submoduleResourceForeground": "#1e66f5",
+        "gitDecoration.untrackedResourceForeground": "#40a02b",
+        "editorMarkerNavigation.background": "#bcc0cc",
+        "editorMarkerNavigationError.background": "#d20f39",
+        "editorMarkerNavigationWarning.background": "#df8e1d",
+        "editorMarkerNavigationInfo.background": "#1e66f5",
+        "merge.currentHeaderBackground": "#158472",
+        "merge.currentContentBackground": "#27403B",
+        "merge.incomingHeaderBackground": "#395F8F",
+        "merge.incomingContentBackground": "#243A5E",
+        "merge.commonHeaderBackground": "#acb0be",
+        "merge.commonContentBackground": "#bcc0cc",
+        "editorSuggestWidget.background": "#bcc0cc",
+        "editorSuggestWidget.border": "#acb0be",
+        "editorSuggestWidget.foreground": "#4c4f69",
+        "editorSuggestWidget.highlightForeground": "#1e66f5",
+        "editorSuggestWidget.selectedBackground": "#acb0be",
+        "editorHoverWidget.foreground": "#4c4f69",
+        "editorHoverWidget.background": "#bcc0cc",
+        "editorHoverWidget.border": "#acb0be",
+        "peekView.border": "#1e66f5",
+        "peekViewEditor.background": "#bcc0cc",
+        "peekViewEditorGutter.background": "#bcc0cc",
+        "peekViewEditor.matchHighlightBackground": "#fe640b40",
+        "peekViewEditor.matchHighlightBorder": "#fe640b",
+        "peekViewResult.background": "#bcc0cc",
+        "peekViewResult.fileForeground": "#4c4f69",
+        "peekViewResult.lineForeground": "#4c4f69",
+        "peekViewResult.matchHighlightBackground": "#fe640b40",
+        "peekViewResult.selectionBackground": "#acb0be",
+        "peekViewResult.selectionForeground": "#4c4f69",
+        "peekViewTitle.background": "#eff1f5",
+        "peekViewTitleDescription.foreground": "#ccccccb3",
+        "peekViewTitleLabel.foreground": "#4c4f69",
+        "icon.foreground": "#4c4f69",
+        "checkbox.background": "#eff1f5",
+        "checkbox.foreground": "#4c4f69",
+        "checkbox.border": "#00000000",
+        "dropdown.background": "#eff1f5",
+        "dropdown.foreground": "#4c4f69",
+        "dropdown.border": "#00000000",
+        "minimapGutter.addedBackground": "#40a02b",
+        "minimapGutter.modifiedBackground": "#04a5e5",
+        "minimapGutter.deletedBackground": "#d20f39",
+        "minimap.findMatchHighlight": "#acb0be",
+        "minimap.selectionHighlight": "#acb0be",
+        "minimap.errorHighlight": "#d20f39",
+        "minimap.warningHighlight": "#df8e1d",
+        "minimap.background": "#eff1f5",
+        "sideBar.dropBackground": "#e6e9ef",
+        "editorGroup.emptyBackground": "#eff1f5",
+        "panelSection.border": "#acb0be",
+        "statusBarItem.activeBackground": "#FFFFFF25",
+        "settings.headerForeground": "#4c4f69",
+        "settings.focusedRowBackground": "#ffffff07",
+        "walkThrough.embeddedEditorBackground": "#00000050",
+        "breadcrumb.activeSelectionForeground": "#4c4f69",
+        "editorGutter.commentRangeForeground": "#7c7f93",
+        "debugExceptionWidget.background": "#bcc0cc",
+        "debugExceptionWidget.border": "#acb0be",
+        "activitusbar.inactiveColour": "#000000",
+        "activitusbar.activeColour": "#000000"
+    }
+}

--- a/themes/Catppuccin-macchiato-color-theme.json
+++ b/themes/Catppuccin-macchiato-color-theme.json
@@ -1,0 +1,2469 @@
+{
+    "name": "Catppuccin Macchiato",
+    "type": "dark",
+    "semanticHighlighting": true,
+    "semanticTokenColors": {
+        "enumMember": {
+            "foreground": "#91d7e3"
+        },
+        "variable.constant": {
+            "foreground": "#eed49f"
+        },
+        "variable.defaultLibrary": {
+            "foreground": "#f5a97f"
+        }
+    },
+    "tokenColors": [
+        {
+            "name": "All variable",
+            "scope": ["variable.language", "variable.other"],
+            "settings": {
+                "foreground": "#f0c6c6"
+            }
+        },
+        {
+            "name": "All function",
+            "scope": ["entity.name.function", "support.function"],
+            "settings": {
+                "foreground": "#8aadf4",
+                "fontStyle": "italic"
+            }
+        },
+        {
+            "name": "All parameter",
+            "scope": [
+                "variable.parameter.function",
+                "variable.parameter.function-call"
+            ],
+            "settings": {
+                "foreground": "#f5bde6",
+                "fontStyle": "italic"
+            }
+        },
+        {
+            "name": "All numeric",
+            "scope": ["constant.numeric.decimal", "constant.numeric.integer"],
+            "settings": {
+                "foreground": "#f5a97f",
+                "fontStyle": "bold"
+            }
+        },
+        {
+            "name": "All types",
+            "scope": "entity.name.type",
+            "settings": {
+                "foreground": "#8aadf4"
+            }
+        },
+        {
+            "name": "All conditionals",
+            "scope": [
+                "keyword.control",
+                "keyword.control.for",
+                "keyword.control.while",
+                "keyword.control.if",
+                "keyword.control.else",
+                "keyword.control.switch",
+                "keyword.control.case"
+            ],
+            "settings": {
+                "foreground": "#ed8796",
+                "fontStyle": "bold"
+            }
+        },
+        {
+            "name": "All punctuation brackets",
+            "scope": [
+                "punctuation.brackets",
+                "punctuation.section",
+                "punctuation.definition"
+            ],
+            "settings": {
+                "foreground": "#8087a2"
+            }
+        },
+        {
+            "name": "All punctuation delimeters",
+            "scope": "punctuation.semi",
+            "settings": {
+                "foreground": "#8bd5ca"
+            }
+        },
+        {
+            "name": "All namespace",
+            "scope": "entity.name.namespace",
+            "settings": {
+                "foreground": "#f4dbd6"
+            }
+        },
+        {
+            "name": "All operators",
+            "scope": [
+                "keyword.operator.comparison",
+                "keyword.operator.assignment",
+                "keyword.operator.arrow.skinny",
+                "keyword.operator.math",
+                "keyword.operator.key-value",
+                "keyword.operator.misc",
+                "keyword.operator.namespace"
+            ],
+            "settings": {
+                "foreground": "#91d7e3",
+                "fontStyle": "bold"
+            }
+        },
+        {
+            "name": "All built-in constants",
+            "scope": "constant.language",
+            "settings": {
+                "foreground": "#b7bdf8",
+                "fontStyle": "italic"
+            }
+        },
+        {
+            "name": "All constants",
+            "scope": "constant.other",
+            "settings": {
+                "foreground": "#f5a97f"
+            }
+        },
+        {
+            "name": "JSON quoted string",
+            "scope": "source.json meta.structure.dictionary.json > string.quoted.json",
+            "settings": {
+                "foreground": "#8bd5ca"
+            }
+        },
+        {
+            "name": "JSON punctuation string",
+            "scope": "source.json meta.structure.dictionary.json > string.quoted.json > punctuation.string",
+            "settings": {
+                "foreground": "#8bd5ca"
+            }
+        },
+        {
+            "name": "JSON punct structure",
+            "scope": "source.json meta.structure.dictionary.json > value.json > string.quoted.json,source.json meta.structure.array.json > value.json > string.quoted.json,source.json meta.structure.dictionary.json > value.json > string.quoted.json > punctuation,source.json meta.structure.array.json > value.json > string.quoted.json > punctuation",
+            "settings": {
+                "foreground": "#a6da95"
+            }
+        },
+        {
+            "name": "JSON property name",
+            "scope": "support.type.property-name.json.comments",
+            "settings": {
+                "foreground": "#8aadf4"
+            }
+        },
+        {
+            "name": "JSON constants",
+            "scope": "constant.language.json.comments",
+            "settings": {
+                "foreground": "#f5a97f"
+            }
+        },
+        {
+            "name": "JSON punctuation",
+            "scope": [
+                "punctuation.separator.dictionary.pair.json.comments",
+                "punctuation.separator.array.json.comments"
+            ],
+            "settings": {
+                "foreground": "#8bd5ca"
+            }
+        },
+        {
+            "name": "JSON brackets",
+            "scope": [
+                "punctuation.definition.dictionary.begin.json.comments",
+                "punctuation.definition.dictionary.end.json.comments",
+                "punctuation.definition.array.begin.json.comments",
+                "punctuation.definition.array.end.json.comments"
+            ],
+            "settings": {
+                "foreground": "#939ab7"
+            }
+        },
+        {
+            "name": "JSON constant language",
+            "scope": "source.json meta.structure.dictionary.json > constant.language.json,source.json meta.structure.array.json > constant.language.json",
+            "settings": {
+                "foreground": "#91d7e3"
+            }
+        },
+        {
+            "name": "JSON property name [VSCODE-CUSTOM]",
+            "scope": "support.type.property-name.json",
+            "settings": {
+                "foreground": "#8bd5ca"
+            }
+        },
+        {
+            "name": "[VSCODE-CUSTOM] JSON Punctuation for Property Name",
+            "scope": "support.type.property-name.json punctuation",
+            "settings": {
+                "foreground": "#8bd5ca"
+            }
+        },
+
+        {
+            "name": "unison punctuation",
+            "scope": "punctuation.definition.delayed.unison,punctuation.definition.list.begin.unison,punctuation.definition.list.end.unison,punctuation.definition.ability.begin.unison,punctuation.definition.ability.end.unison,punctuation.operator.assignment.as.unison,punctuation.separator.pipe.unison,punctuation.separator.delimiter.unison,punctuation.definition.hash.unison",
+            "settings": {
+                "foreground": "#8bd5ca"
+            }
+        },
+        {
+            "name": "haskell variable generic-type",
+            "scope": "variable.other.generic-type.haskell",
+            "settings": {
+                "foreground": "#ed8796"
+            }
+        },
+        {
+            "name": "haskell storage type",
+            "scope": "storage.type.haskell",
+            "settings": {
+                "foreground": "#eed49f"
+            }
+        },
+        {
+            "name": "support.variable.magic.python",
+            "scope": "support.variable.magic.python",
+            "settings": {
+                "foreground": "#cad3f5"
+            }
+        },
+        {
+            "name": "punctuation.separator.parameters.python",
+            "scope": "punctuation.separator.period.python,punctuation.separator.element.python,punctuation.parenthesis.begin.python,punctuation.parenthesis.end.python",
+            "settings": {
+                "foreground": "#cad3f5"
+            }
+        },
+        {
+            "name": "variable.parameter.function.language.special.self.python",
+            "scope": "variable.parameter.function.language.special.self.python",
+            "settings": {
+                "foreground": "#f5a97f"
+            }
+        },
+
+        {
+            "name": "Rust modifier",
+            "scope": "storage.modifier.lifetime.rust",
+            "settings": {
+                "foreground": "#cad3f5"
+            }
+        },
+        {
+            "name": "Rust types",
+            "scope": "entity.name.type.rust",
+            "settings": {
+                "foreground": "#eed49f"
+            }
+        },
+        {
+            "name": "Rust functions std",
+            "scope": "support.function.std.rust",
+            "settings": {
+                "foreground": "#8aadf4"
+            }
+        },
+        {
+            "name": "Rust functions",
+            "scope": "entity.name.function.rust",
+            "settings": {
+                "foreground": "#8aadf4",
+                "fontStyle": "italic"
+            }
+        },
+        {
+            "name": "Rust function keyword",
+            "scope": "keyword.other.fn.rust",
+            "settings": {
+                "foreground": "#ee99a0"
+            }
+        },
+        {
+            "name": "Rust conditionals",
+            "scope": "keyword.control.rust",
+            "settings": {
+                "foreground": "#c6a0f6",
+                "fontStyle": "bold"
+            }
+        },
+        {
+            "name": "Rust punctuation brackets",
+            "scope": [
+                "punctuation.brackets.curly.rust",
+                "punctuation.brackets.round.rust",
+                "punctuation.brackets.square.rust",
+                "punctuation.brackets.attribute.rust"
+            ],
+            "settings": {
+                "foreground": "#8087a2"
+            }
+        },
+        {
+            "name": "Rust namespace",
+            "scope": "entity.name.namespace.rust",
+            "settings": {
+                "foreground": "#f4dbd6"
+            }
+        },
+        {
+            "name": "Rust punctuation delimeters",
+            "scope": "punctuation.semi.rust",
+            "settings": {
+                "foreground": "#8bd5ca"
+            }
+        },
+        {
+            "name": "Rust operators",
+            "scope": [
+                "keyword.operator.comparison.rust",
+                "keyword.operator.assignment.equal.rust",
+                "keyword.operator.arrow.skinny.rust",
+                "keyword.operator.math.rust",
+                "keyword.operator.key-value.rust",
+                "keyword.operator.misc.rust"
+            ],
+            "settings": {
+                "foreground": "#91d7e3"
+            }
+        },
+        {
+            "name": "Rust operator namespaces",
+            "scope": "keyword.operator.namespace.rust",
+            "settings": {
+                "foreground": "#8bd5ca"
+            }
+        },
+        {
+            "name": "Rust definition attributes",
+            "scope": [
+                "punctuation.definition.attribute.rust",
+                "keyword.operator.attribute.inner.rust"
+            ],
+            "settings": {
+                "foreground": "#8bd5ca",
+                "fontStyle": "bold"
+            }
+        },
+        {
+            "name": "Rust math logic",
+            "scope": "constant.numeric.decimal.rust",
+            "settings": {
+                "foreground": "#f5a97f"
+            }
+        },
+        {
+            "name": "Rust constants",
+            "scope": "support.constant.core.rust",
+            "settings": {
+                "foreground": "#eed49f"
+            }
+        },
+        {
+            "name": "Rust entity name",
+            "scope": "entity.name.lifetime.rust",
+            "settings": {
+                "foreground": "#f5a97f"
+            }
+        },
+        {
+            "name": "Rust variable",
+            "scope": ["variable.language.rust", "variable.other.rust"],
+            "settings": {
+                "foreground": "#cad3f5",
+                "fontStyle": "italic"
+            }
+        },
+        {
+            "name": "Rust misc operators",
+            "scope": "keyword.operator.misc.rust",
+            "settings": {
+                "foreground": "#cad3f5"
+            }
+        },
+        {
+            "name": "Rust sigil operator",
+            "scope": "keyword.operator.sigil.rust",
+            "settings": {
+                "foreground": "#ed8796"
+            }
+        },
+
+        {
+            "name": "Lua operators",
+            "scope": "keyword.operator.lua",
+            "settings": {
+                "foreground": "#91d7e3",
+                "fontStyle": "bold"
+            }
+        },
+        {
+            "name": "Lua numeric",
+            "scope": "constant.numeric.integer.lua",
+            "settings": {
+                "foreground": "#f5a97f",
+                "fontStyle": "bold"
+            }
+        },
+        {
+            "name": "Lua other vars",
+            "scope": "variable.other.lua",
+            "settings": {
+                "foreground": "#b7bdf8",
+                "fontStyle": "italic"
+            }
+        },
+        {
+            "name": "Lua brackets",
+            "scope": [
+                "punctuation.definition.parameters.end.lua",
+                "punctuation.definition.parameters.begin.lua"
+            ],
+            "settings": {
+                "foreground": "#8087a2"
+            }
+        },
+
+        {
+            "name": "C++ Puct Delimeters",
+            "scope": "punctuation.terminator.statement.cpp",
+            "settings": {
+                "foreground": "#8bd5ca",
+                "fontStyle": "bold"
+            }
+        },
+        {
+            "name": "C++ Operators",
+            "scope": [
+                "punctuation.separator.scope-resolution.cpp",
+                "punctuation.separator.scope-resolution.namespace.alias.cpp",
+                "punctuation.separator.scope-resolution.namespace.using.cpp"
+            ],
+            "settings": {
+                "foreground": "#91d7e3",
+                "fontStyle": "bold"
+            }
+        },
+        {
+            "name": "C++ function",
+            "scope": "meta.function.c,meta.function.cpp",
+            "settings": {
+                "foreground": "#8bd5ca"
+            }
+        },
+
+        {
+            "name": "C++ constructor/destructor",
+            "scope": [
+                "entity.name.function.definition.special.constructor",
+                "entity.name.function.definition.special.member.destructor"
+            ],
+            "settings": {
+                "foreground": "#b7bdf8"
+            }
+        },
+        {
+            "name": "C++ directive",
+            "scope": [
+                "keyword.control.directive",
+                "keyword.other.using.directive",
+                "punctuation.definition.directive"
+            ],
+            "settings": {
+                "foreground": "#8bd5ca",
+                "fontStyle": "italic"
+            }
+        },
+        {
+            "name": "C++ ifdef directive",
+            "scope": [
+                "keyword.control.directive.conditional.ifdef.cpp",
+                "keyword.control.directive.else.cpp",
+                "keyword.control.directive.else.cpp punctuation.definition.directive.cpp",
+                "keyword.control.directive.endif.cpp",
+                "keyword.control.directive.conditional.ifdef.cpp punctuation.definition.directive.cpp",
+                "keyword.control.directive.endif.cpp punctuation.definition.directive.cpp"
+            ],
+            "settings": {
+                "foreground": "#ed8796"
+            }
+        },
+        {
+            "name": "C++ misc",
+            "scope": [
+                "entity.name.other.preprocessor.macro.predefined.probably",
+                "entity.name.scope-resolution.cpp"
+            ],
+            "settings": {
+                "foreground": "#f4dbd6",
+                "fontStyle": "italic"
+            }
+        },
+        {
+            "name": "C++ pointer/reference",
+            "scope": [
+                "storage.modifier.pointer.cpp",
+                "storage.modifier.reference.cpp"
+            ],
+            "settings": {
+                "foreground": "#8bd5ca"
+            }
+        },
+        {
+            "name": "C++ loop/conditional",
+            "scope": [
+                "keyword.control.for",
+                "keyword.control.while",
+                "keyword.control.if",
+                "keyword.control.else",
+                "keyword.control.switch",
+                "keyword.control.case"
+            ],
+            "settings": {
+                "foreground": "#c6a0f6",
+                "fontStyle": "bold"
+            }
+        },
+        {
+            "name": "C++ return",
+            "scope": "keyword.control.return",
+            "settings": {
+                "foreground": "#f5bde6"
+            }
+        },
+        {
+            "name": "C++ block",
+            "scope": [
+                "punctuation.section.block.begin.bracket.curly.cpp",
+                "punctuation.section.block.end.bracket.curly.cpp",
+                "punctuation.terminator.statement.c",
+                "punctuation.section.block.begin.bracket.curly.c",
+                "punctuation.section.block.end.bracket.curly.c",
+                "punctuation.section.parens.begin.bracket.round.c",
+                "punctuation.section.parens.end.bracket.round.c",
+                "punctuation.section.parameters.begin.bracket.round.c",
+                "punctuation.section.parameters.end.bracket.round.c"
+            ],
+            "settings": {
+                "foreground": "#cad3f5"
+            }
+        },
+        {
+            "name": "C++ storage type modifier",
+            "scope": "storage.type.built-in.primitive.cpp",
+            "settings": {
+                "foreground": "#eed49f"
+            }
+        },
+        {
+            "name": "C++/C#",
+            "scope": [
+                "entity.name.label.cs",
+                "entity.name.scope-resolution.function.call",
+                "entity.name.scope-resolution.function.definition"
+            ],
+            "settings": {
+                "foreground": "#f5a97f"
+            }
+        },
+        {
+            "name": "support.constant.edge",
+            "scope": "support.constant.edge",
+            "settings": {
+                "foreground": "#ed8796"
+            }
+        },
+        {
+            "name": "regexp constant character-class",
+            "scope": "constant.other.character-class.regexp",
+            "settings": {
+                "foreground": "#8bd5ca"
+            }
+        },
+        {
+            "name": "regexp operator.quantifier",
+            "scope": "keyword.operator.quantifier.regexp",
+            "settings": {
+                "foreground": "#eed49f"
+            }
+        },
+        {
+            "name": "punctuation.definition",
+            "scope": "punctuation.definition.string.begin,punctuation.definition.string.end",
+            "settings": {
+                "foreground": "#a6da95"
+            }
+        },
+        {
+            "name": "Comment Markup Link",
+            "scope": "comment markup.link",
+            "settings": {
+                "foreground": "#6e738d"
+            }
+        },
+        {
+            "name": "markup diff",
+            "scope": "markup.changed.diff",
+            "settings": {
+                "foreground": "#f5a97f"
+            }
+        },
+        {
+            "name": "diff",
+            "scope": "meta.diff.header.from-file,meta.diff.header.to-file,punctuation.definition.from-file.diff,punctuation.definition.to-file.diff",
+            "settings": {
+                "foreground": "#8aadf4"
+            }
+        },
+        {
+            "name": "inserted.diff",
+            "scope": "markup.inserted.diff",
+            "settings": {
+                "foreground": "#a6da95"
+            }
+        },
+        {
+            "name": "deleted.diff",
+            "scope": "markup.deleted.diff",
+            "settings": {
+                "foreground": "#8bd5ca"
+            }
+        },
+        {
+            "name": "Quote multi",
+            "scope": [
+                "string.quoted.docstring.multi",
+                "string.quoted.multi",
+                "source.python string.quoted.docstring.multi.python punctuation.definition.string.begin.python",
+                "source.python string.quoted.docstring.multi.python punctuation.definition.string.end.python",
+                "source.python string.quoted.multi.python punctuation.definition.string.begin.python",
+                "source.python string.quoted.multi.python punctuation.definition.string.end.python",
+                "markup.fenced_code.block"
+            ],
+            "settings": {
+                "foreground": "#8bd5ca",
+                "fontStyle": "italic"
+            }
+        },
+        {
+            "name": "js/ts punctuation separator key-value",
+            "scope": "punctuation.separator.key-value",
+            "settings": {
+                "foreground": "#cad3f5"
+            }
+        },
+        {
+            "name": "js/ts import keyword",
+            "scope": "keyword.operator.expression.import",
+            "settings": {
+                "foreground": "#8aadf4"
+            }
+        },
+        {
+            "name": "math js/ts",
+            "scope": "support.constant.math",
+            "settings": {
+                "foreground": "#f5a97f"
+            }
+        },
+        {
+            "name": "math property js/ts",
+            "scope": "support.constant.property.math",
+            "settings": {
+                "foreground": "#eed49f"
+            }
+        },
+        {
+            "name": "js/ts variable.other.constant",
+            "scope": "variable.other.constant",
+            "settings": {
+                "foreground": "#cad3f5"
+            }
+        },
+        {
+            "name": "java type",
+            "scope": [
+                "storage.type.annotation.java",
+                "storage.type.object.array.java"
+            ],
+            "settings": {
+                "foreground": "#f5a97f"
+            }
+        },
+        {
+            "name": "java source",
+            "scope": "source.java",
+            "settings": {
+                "foreground": "#8bd5ca"
+            }
+        },
+        {
+            "name": "java modifier.import",
+            "scope": "punctuation.section.block.begin.java,punctuation.section.block.end.java,punctuation.definition.method-parameters.begin.java,punctuation.definition.method-parameters.end.java,meta.method.identifier.java,punctuation.section.method.begin.java,punctuation.section.method.end.java,punctuation.terminator.java,punctuation.section.class.begin.java,punctuation.section.class.end.java,punctuation.section.inner-class.begin.java,punctuation.section.inner-class.end.java,meta.method-call.java,punctuation.section.class.begin.bracket.curly.java,punctuation.section.class.end.bracket.curly.java,punctuation.section.method.begin.bracket.curly.java,punctuation.section.method.end.bracket.curly.java,punctuation.separator.period.java,punctuation.bracket.angle.java,punctuation.definition.annotation.java,meta.method.body.java",
+            "settings": {
+                "foreground": "#cad3f5"
+            }
+        },
+        {
+            "name": "java modifier.import",
+            "scope": "meta.method.java",
+            "settings": {
+                "foreground": "#8aadf4"
+            }
+        },
+        {
+            "name": "java modifier.import",
+            "scope": "storage.modifier.import.java,storage.type.java,storage.type.generic.java",
+            "settings": {
+                "foreground": "#f5a97f"
+            }
+        },
+        {
+            "name": "java instanceof",
+            "scope": "keyword.operator.instanceof.java",
+            "settings": {
+                "foreground": "#ed8796"
+            }
+        },
+        {
+            "name": "java variable.name",
+            "scope": "meta.definition.variable.name.java",
+            "settings": {
+                "foreground": "#cad3f5"
+            }
+        },
+        {
+            "name": "operator logical",
+            "scope": [
+                "keyword.operator.logical",
+                "keyword.operator.ternary"
+            ],
+            "settings": {
+                "foreground": "#91d7e3",
+                "fontStyle": "bold"
+            }
+        },
+        {
+            "name": "operator bitwise",
+            "scope": "keyword.operator.bitwise",
+            "settings": {
+                "foreground": "#91d7e3"
+            }
+        },
+        {
+            "name": "operator channel",
+            "scope": "keyword.operator.channel",
+            "settings": {
+                "foreground": "#91d7e3"
+            }
+        },
+        {
+            "name": "support.constant.property-value.scss",
+            "scope": "support.constant.property-value.scss,support.constant.property-value.css",
+            "settings": {
+                "foreground": "#eed49f"
+            }
+        },
+        {
+            "name": "CSS/SCSS/LESS Operators",
+            "scope": "keyword.operator.css,keyword.operator.scss,keyword.operator.less",
+            "settings": {
+                "foreground": "#91d7e3"
+            }
+        },
+        {
+            "name": "css color standard name",
+            "scope": "support.constant.color.w3c-standard-color-name.css,support.constant.color.w3c-standard-color-name.scss",
+            "settings": {
+                "foreground": "#eed49f"
+            }
+        },
+        {
+            "name": "css comma",
+            "scope": "punctuation.separator.list.comma.css",
+            "settings": {
+                "foreground": "#cad3f5"
+            }
+        },
+        {
+            "name": "css attribute-name.id",
+            "scope": "support.constant.color.w3c-standard-color-name.css",
+            "settings": {
+                "foreground": "#eed49f"
+            }
+        },
+        {
+            "name": "css property-name",
+            "scope": "support.type.vendored.property-name.css",
+            "settings": {
+                "foreground": "#91d7e3"
+            }
+        },
+        {
+            "name": "js/ts module",
+            "scope": "support.module.node,support.type.object.module,support.module.node",
+            "settings": {
+                "foreground": "#f5a97f"
+            }
+        },
+        {
+            "name": "entity.name.type.module",
+            "scope": "entity.name.type.module",
+            "settings": {
+                "foreground": "#f5a97f"
+            }
+        },
+        {
+            "name": "js variable readwrite",
+            "scope": "variable.other.readwrite,meta.object-literal.key,support.variable.property,support.variable.object.process,support.variable.object.node",
+            "settings": {
+                "foreground": "#cad3f5"
+            }
+        },
+        {
+            "name": "js/ts json",
+            "scope": "support.constant.json",
+            "settings": {
+                "foreground": "#eed49f"
+            }
+        },
+        {
+            "name": "js/ts Keyword",
+            "scope": [
+                "keyword.operator.expression.instanceof",
+                "keyword.operator.new",
+                "keyword.operator.ternary",
+                "keyword.operator.optional",
+                "keyword.operator.expression.keyof"
+            ],
+            "settings": {
+                "foreground": "#ed8796"
+            }
+        },
+        {
+            "name": "js/ts console",
+            "scope": "support.type.object.console",
+            "settings": {
+                "foreground": "#8bd5ca"
+            }
+        },
+        {
+            "name": "js/ts support.variable.property.process",
+            "scope": "support.variable.property.process",
+            "settings": {
+                "foreground": "#eed49f"
+            }
+        },
+        {
+            "name": "js console function",
+            "scope": "entity.name.function,support.function.console",
+            "settings": {
+                "foreground": "#8aadf4"
+            }
+        },
+        {
+            "name": "operator",
+            "scope": "keyword.operator.delete",
+            "settings": {
+                "foreground": "#ed8796"
+            }
+        },
+        {
+            "name": "js dom",
+            "scope": "support.type.object.dom",
+            "settings": {
+                "foreground": "#91d7e3"
+            }
+        },
+        {
+            "name": "js dom variable",
+            "scope": ["support.variable.dom", "support.variable.property.dom"],
+            "settings": {
+                "foreground": "#8bd5ca"
+            }
+        },
+        {
+            "name": "keyword.operator",
+            "scope": [
+                "keyword.operator.arithmetic",
+                "keyword.operator.comparison",
+                "keyword.operator.decrement",
+                "keyword.operator.increment",
+                "keyword.operator.relational"
+            ],
+            "settings": {
+                "foreground": "#91d7e3",
+                "fontStyle": "bold"
+            }
+        },
+        {
+            "name": "C operators",
+            "scope": [
+                "keyword.operator.c",
+                "keyword.operator.increment.c",
+                "keyword.operator.decrement.c",
+                "keyword.operator.bitwise.shift.c",
+                "keyword.operator.cpp",
+                "keyword.operator.increment.cpp",
+                "keyword.operator.decrement.cpp",
+                "keyword.operator.bitwise.shift.cpp"
+            ],
+            "settings": {
+                "foreground": "#91d7e3",
+                "fontStyle": "bold"
+            }
+        },
+        {
+            "name": "Punctuation",
+            "scope": "punctuation.separator.delimiter",
+            "settings": {
+                "foreground": "#cad3f5"
+            }
+        },
+        {
+            "name": "Other punctuation .c",
+            "scope": "punctuation.separator.c,punctuation.separator.cpp",
+            "settings": {
+                "foreground": "#ed8796"
+            }
+        },
+        {
+            "name": "C type posix-reserved",
+            "scope": "support.type.posix-reserved.c,support.type.posix-reserved.cpp",
+            "settings": {
+                "foreground": "#91d7e3"
+            }
+        },
+        {
+            "name": "keyword.operator.sizeof.c",
+            "scope": "keyword.operator.sizeof.c,keyword.operator.sizeof.cpp",
+            "settings": {
+                "foreground": "#ed8796"
+            }
+        },
+        {
+            "name": "python type",
+            "scope": "support.type.python",
+            "settings": {
+                "foreground": "#91d7e3"
+            }
+        },
+        {
+            "name": "python block",
+            "scope": "punctuation.definition.arguments.begin.python,punctuation.definition.arguments.end.python,punctuation.separator.arguments.python,punctuation.definition.list.begin.python,punctuation.definition.list.end.python",
+            "settings": {
+                "foreground": "#cad3f5"
+            }
+        },
+        {
+            "name": "python function-call.generic",
+            "scope": "meta.function-call.generic.python",
+            "settings": {
+                "foreground": "#8aadf4",
+                "fontStyle": "italic"
+            }
+        },
+        {
+            "name": "python placeholder reset to normal string",
+            "scope": "constant.character.format.placeholder.other.python",
+            "settings": {
+                "foreground": "#eed49f"
+            }
+        },
+        {
+            "name": "Operators",
+            "scope": "keyword.operator",
+            "settings": {
+                "foreground": "#91d7e3",
+                "fontStyle": "bold"
+            }
+        },
+        {
+            "name": "Keywords",
+            "scope": "keyword",
+            "settings": {
+                "foreground": "#ed8796"
+            }
+        },
+        {
+            "name": "Namespaces",
+            "scope": "entity.name.namespace",
+            "settings": {
+                "foreground": "#f5a97f"
+            }
+        },
+        {
+            "name": "Language variables",
+            "scope": "variable.language",
+            "settings": {
+                "foreground": "#f5a97f"
+            }
+        },
+        {
+            "name": "Java Variables",
+            "scope": "token.variable.parameter.java",
+            "settings": {
+                "foreground": "#cad3f5"
+            }
+        },
+        {
+            "name": "Java Imports",
+            "scope": "import.storage.java",
+            "settings": {
+                "foreground": "#f5a97f"
+            }
+        },
+        {
+            "name": "Packages",
+            "scope": "token.package.keyword",
+            "settings": {
+                "foreground": "#ed8796"
+            }
+        },
+        {
+            "name": "Packages",
+            "scope": "token.package",
+            "settings": {
+                "foreground": "#cad3f5"
+            }
+        },
+        {
+            "name": "Functions",
+            "scope": [
+                "entity.name.function",
+                "meta.require",
+                "support.function.any-method",
+                "variable.function"
+            ],
+            "settings": {
+                "foreground": "#8aadf4",
+                "fontStyle": "italic"
+            }
+        },
+        {
+            "name": "Classes",
+            "scope": "entity.name.type.namespace",
+            "settings": {
+                "foreground": "#f5a97f"
+            }
+        },
+        {
+            "name": "Classes",
+            "scope": "support.class, entity.name.type.class",
+            "settings": {
+                "foreground": "#f5a97f"
+            }
+        },
+        {
+            "name": "Class name",
+            "scope": "entity.name.class.identifier.namespace.type",
+            "settings": {
+                "foreground": "#f5a97f"
+            }
+        },
+        {
+            "name": "Class name",
+            "scope": [
+                "entity.name.class",
+                "variable.other.class.js",
+                "variable.other.class.ts"
+            ],
+            "settings": {
+                "foreground": "#f5a97f"
+            }
+        },
+        {
+            "name": "Class name php",
+            "scope": "variable.other.class.php",
+            "settings": {
+                "foreground": "#8bd5ca"
+            }
+        },
+        {
+            "name": "Type Name",
+            "scope": "entity.name.type",
+            "settings": {
+                "foreground": "#f5a97f"
+            }
+        },
+        {
+            "name": "Keyword Control",
+            "scope": "keyword.control",
+            "settings": {
+                "foreground": "#ed8796"
+            }
+        },
+        {
+            "name": "Control Elements",
+            "scope": "control.elements, keyword.operator.less",
+            "settings": {
+                "foreground": "#eed49f"
+            }
+        },
+        {
+            "name": "Methods",
+            "scope": "keyword.other.special-method",
+            "settings": {
+                "foreground": "#8aadf4"
+            }
+        },
+        {
+            "name": "Storage",
+            "scope": "storage",
+            "settings": {
+                "foreground": "#ed8796"
+            }
+        },
+        {
+            "name": "Storage JS TS",
+            "scope": "token.storage",
+            "settings": {
+                "foreground": "#ed8796"
+            }
+        },
+        {
+            "name": "Source Js Keyword Operator Delete,source Js Keyword Operator In,source Js Keyword Operator Of,source Js Keyword Operator Instanceof,source Js Keyword Operator New,source Js Keyword Operator Typeof,source Js Keyword Operator Void",
+            "scope": "keyword.operator.expression.delete,keyword.operator.expression.in,keyword.operator.expression.of,keyword.operator.expression.instanceof,keyword.operator.new,keyword.operator.expression.typeof,keyword.operator.expression.void",
+            "settings": {
+                "foreground": "#ed8796"
+            }
+        },
+        {
+            "name": "Java Storage",
+            "scope": "token.storage.type.java",
+            "settings": {
+                "foreground": "#f5a97f"
+            }
+        },
+        {
+            "name": "Support",
+            "scope": "support.function",
+            "settings": {
+                "foreground": "#91d7e3"
+            }
+        },
+        {
+            "name": "Support type",
+            "scope": "support.type.property-name",
+            "settings": {
+                "foreground": "#cad3f5"
+            }
+        },
+        {
+            "name": "Support type",
+            "scope": "support.constant.property-value",
+            "settings": {
+                "foreground": "#cad3f5"
+            }
+        },
+        {
+            "name": "Support type",
+            "scope": "support.constant.font-name",
+            "settings": {
+                "foreground": "#eed49f"
+            }
+        },
+        {
+            "name": "Meta tag",
+            "scope": "meta.tag",
+            "settings": {
+                "foreground": "#cad3f5"
+            }
+        },
+        {
+            "name": "Strings",
+            "scope": "string",
+            "settings": {
+                "foreground": "#a6da95"
+            }
+        },
+        {
+            "name": "Inherited Class",
+            "scope": "entity.other.inherited-class",
+            "settings": {
+                "foreground": "#f5a97f"
+            }
+        },
+        {
+            "name": "Constant other symbol",
+            "scope": "constant.other.symbol",
+            "settings": {
+                "foreground": "#91d7e3"
+            }
+        },
+        {
+            "name": "Integers",
+            "scope": "constant.numeric",
+            "settings": {
+                "foreground": "#f5a97f"
+            }
+        },
+        {
+            "name": "Constants",
+            "scope": "constant",
+            "settings": {
+                "foreground": "#eed49f"
+            }
+        },
+        {
+            "name": "Constants",
+            "scope": "punctuation.definition.constant",
+            "settings": {
+                "foreground": "#eed49f"
+            }
+        },
+        {
+            "name": "Tags",
+            "scope": "entity.name.tag",
+            "settings": {
+                "foreground": "#8bd5ca"
+            }
+        },
+        {
+            "name": "Attributes",
+            "scope": "entity.other.attribute-name",
+            "settings": {
+                "foreground": "#eed49f"
+            }
+        },
+        {
+            "name": "Attribute IDs",
+            "scope": "entity.other.attribute-name.id",
+            "settings": {
+                "fontStyle": "",
+                "foreground": "#8aadf4"
+            }
+        },
+        {
+            "name": "Attribute class",
+            "scope": "entity.other.attribute-name.class.css",
+            "settings": {
+                "fontStyle": "",
+                "foreground": "#eed49f"
+            }
+        },
+        {
+            "name": "Selector",
+            "scope": "meta.selector",
+            "settings": {
+                "foreground": "#ed8796"
+            }
+        },
+        {
+            "name": "Headings",
+            "scope": "markup.heading",
+            "settings": {
+                "foreground": "#8bd5ca"
+            }
+        },
+        {
+            "name": "Headings",
+            "scope": "markup.heading punctuation.definition.heading, entity.name.section",
+            "settings": {
+                "foreground": "#8aadf4"
+            }
+        },
+        {
+            "name": "Units",
+            "scope": "keyword.other.unit",
+            "settings": {
+                "foreground": "#8bd5ca"
+            }
+        },
+        {
+            "name": "Bold",
+            "scope": "markup.bold,todo.bold",
+            "settings": {
+                "foreground": "#eed49f"
+            }
+        },
+        {
+            "name": "Bold",
+            "scope": "punctuation.definition.bold",
+            "settings": {
+                "foreground": "#f5a97f"
+            }
+        },
+        {
+            "name": "markup Italic",
+            "scope": "markup.italic, punctuation.definition.italic,todo.emphasis",
+            "settings": {
+                "foreground": "#ed8796"
+            }
+        },
+        {
+            "name": "emphasis md",
+            "scope": "emphasis md",
+            "settings": {
+                "foreground": "#ed8796"
+            }
+        },
+        {
+            "name": "[VSCODE-CUSTOM] Markdown headings",
+            "scope": "entity.name.section.markdown",
+            "settings": {
+                "foreground": "#8bd5ca"
+            }
+        },
+        {
+            "name": "[VSCODE-CUSTOM] Markdown heading Punctuation Definition",
+            "scope": "punctuation.definition.heading.markdown",
+            "settings": {
+                "foreground": "#8bd5ca"
+            }
+        },
+        {
+            "name": "punctuation.definition.list.begin.markdown",
+            "scope": "punctuation.definition.list.begin.markdown",
+            "settings": {
+                "foreground": "#8bd5ca"
+            }
+        },
+        {
+            "name": "[VSCODE-CUSTOM] Markdown heading setext",
+            "scope": "markup.heading.setext",
+            "settings": {
+                "foreground": "#cad3f5"
+            }
+        },
+        {
+            "name": "[VSCODE-CUSTOM] Markdown Punctuation Definition Bold",
+            "scope": "punctuation.definition.bold.markdown",
+            "settings": {
+                "foreground": "#eed49f"
+            }
+        },
+        {
+            "name": "[VSCODE-CUSTOM] Markdown Inline Raw",
+            "scope": "markup.inline.raw.markdown",
+            "settings": {
+                "foreground": "#a6da95"
+            }
+        },
+        {
+            "name": "[VSCODE-CUSTOM] Markdown Inline Raw",
+            "scope": "markup.inline.raw.string.markdown",
+            "settings": {
+                "foreground": "#a6da95"
+            }
+        },
+        {
+            "name": "[VSCODE-CUSTOM] Markdown List Punctuation Definition",
+            "scope": "punctuation.definition.list.markdown",
+            "settings": {
+                "foreground": "#8bd5ca"
+            }
+        },
+        {
+            "name": "[VSCODE-CUSTOM] Markdown Punctuation Definition String",
+            "scope": [
+                "punctuation.definition.string.begin.markdown",
+                "punctuation.definition.string.end.markdown",
+                "punctuation.definition.metadata.markdown"
+            ],
+            "settings": {
+                "foreground": "#8bd5ca"
+            }
+        },
+        {
+            "name": "beginning.punctuation.definition.list.markdown",
+            "scope": ["beginning.punctuation.definition.list.markdown"],
+            "settings": {
+                "foreground": "#8bd5ca"
+            }
+        },
+        {
+            "name": "[VSCODE-CUSTOM] Markdown Punctuation Definition Link",
+            "scope": "punctuation.definition.metadata.markdown",
+            "settings": {
+                "foreground": "#8bd5ca"
+            }
+        },
+        {
+            "name": "[VSCODE-CUSTOM] Markdown Underline Link/Image",
+            "scope": "markup.underline.link.markdown,markup.underline.link.image.markdown",
+            "settings": {
+                "foreground": "#ed8796"
+            }
+        },
+        {
+            "name": "[VSCODE-CUSTOM] Markdown Link Title/Description",
+            "scope": "string.other.link.title.markdown,string.other.link.description.markdown",
+            "settings": {
+                "foreground": "#8aadf4"
+            }
+        },
+        {
+            "name": "Regular Expressions",
+            "scope": "string.regexp",
+            "settings": {
+                "foreground": "#91d7e3"
+            }
+        },
+        {
+            "name": "Escape Characters",
+            "scope": "constant.character.escape",
+            "settings": {
+                "foreground": "#91d7e3"
+            }
+        },
+        {
+            "name": "Embedded",
+            "scope": "punctuation.section.embedded, variable.interpolation",
+            "settings": {
+                "foreground": "#8bd5ca"
+            }
+        },
+        {
+            "name": "Embedded",
+            "scope": "punctuation.section.embedded.begin,punctuation.section.embedded.end",
+            "settings": {
+                "foreground": "#ed8796"
+            }
+        },
+        {
+            "name": "illegal",
+            "scope": "invalid.illegal",
+            "settings": {
+                "foreground": "#ffffff"
+            }
+        },
+        {
+            "name": "illegal",
+            "scope": "invalid.illegal.bad-ampersand.html",
+            "settings": {
+                "foreground": "#cad3f5"
+            }
+        },
+        {
+            "name": "Broken",
+            "scope": "invalid.broken",
+            "settings": {
+                "foreground": "#ffffff"
+            }
+        },
+        {
+            "name": "Deprecated",
+            "scope": "invalid.deprecated",
+            "settings": {
+                "foreground": "#ffffff"
+            }
+        },
+        {
+            "name": "Unimplemented",
+            "scope": "invalid.unimplemented",
+            "settings": {
+                "foreground": "#ffffff"
+            }
+        },
+        {
+            "name": "laravel blade tag",
+            "scope": "text.html.laravel-blade source.php.embedded.line.html entity.name.tag.laravel-blade",
+            "settings": {
+                "foreground": "#ed8796"
+            }
+        },
+        {
+            "name": "laravel blade @",
+            "scope": "text.html.laravel-blade source.php.embedded.line.html support.constant.laravel-blade",
+            "settings": {
+                "foreground": "#ed8796"
+            }
+        },
+        {
+            "name": "use statement for other classes",
+            "scope": "support.other.namespace.use.php,support.other.namespace.use-as.php,support.other.namespace.php,entity.other.alias.php,meta.interface.php",
+            "settings": {
+                "foreground": "#f5a97f"
+            }
+        },
+        {
+            "name": "error suppression",
+            "scope": "keyword.operator.error-control.php",
+            "settings": {
+                "foreground": "#ed8796"
+            }
+        },
+        {
+            "name": "php instanceof",
+            "scope": "keyword.operator.type.php",
+            "settings": {
+                "foreground": "#ed8796"
+            }
+        },
+        {
+            "name": "style double quoted array index normal begin",
+            "scope": "punctuation.section.array.begin.php",
+            "settings": {
+                "foreground": "#cad3f5"
+            }
+        },
+        {
+            "name": "style double quoted array index normal end",
+            "scope": "punctuation.section.array.end.php",
+            "settings": {
+                "foreground": "#cad3f5"
+            }
+        },
+        {
+            "name": "php illegal.non-null-typehinted",
+            "scope": "invalid.illegal.non-null-typehinted.php",
+            "settings": {
+                "foreground": "#f44747"
+            }
+        },
+        {
+            "name": "php types",
+            "scope": "storage.type.php,meta.other.type.phpdoc.php,keyword.other.type.php,keyword.other.array.phpdoc.php",
+            "settings": {
+                "foreground": "#f5a97f"
+            }
+        },
+        {
+            "name": "php call-function",
+            "scope": "meta.function-call.php,meta.function-call.object.php,meta.function-call.static.php",
+            "settings": {
+                "foreground": "#8aadf4"
+            }
+        },
+        {
+            "name": "php function-resets",
+            "scope": "punctuation.definition.parameters.begin.bracket.round.php,punctuation.definition.parameters.end.bracket.round.php,punctuation.separator.delimiter.php,punctuation.section.scope.begin.php,punctuation.section.scope.end.php,punctuation.terminator.expression.php,punctuation.definition.arguments.begin.bracket.round.php,punctuation.definition.arguments.end.bracket.round.php,punctuation.definition.storage-type.begin.bracket.round.php,punctuation.definition.storage-type.end.bracket.round.php,punctuation.definition.array.begin.bracket.round.php,punctuation.definition.array.end.bracket.round.php,punctuation.definition.begin.bracket.round.php,punctuation.definition.end.bracket.round.php,punctuation.definition.begin.bracket.curly.php,punctuation.definition.end.bracket.curly.php,punctuation.definition.section.switch-block.end.bracket.curly.php,punctuation.definition.section.switch-block.start.bracket.curly.php,punctuation.definition.section.switch-block.begin.bracket.curly.php,punctuation.definition.section.switch-block.end.bracket.curly.php",
+            "settings": {
+                "foreground": "#cad3f5"
+            }
+        },
+        {
+            "name": "support php constants",
+            "scope": "support.constant.ext.php,support.constant.std.php,support.constant.core.php,support.constant.parser-token.php",
+            "settings": {
+                "foreground": "#eed49f"
+            }
+        },
+        {
+            "name": "php goto",
+            "scope": "entity.name.goto-label.php,support.other.php",
+            "settings": {
+                "foreground": "#8aadf4"
+            }
+        },
+        {
+            "name": "php logical/bitwise operator",
+            "scope": "keyword.operator.logical.php,keyword.operator.bitwise.php,keyword.operator.arithmetic.php",
+            "settings": {
+                "foreground": "#91d7e3"
+            }
+        },
+        {
+            "name": "php regexp operator",
+            "scope": "keyword.operator.regexp.php",
+            "settings": {
+                "foreground": "#ed8796"
+            }
+        },
+        {
+            "name": "php comparison",
+            "scope": "keyword.operator.comparison.php",
+            "settings": {
+                "foreground": "#91d7e3"
+            }
+        },
+        {
+            "name": "php heredoc/nowdoc",
+            "scope": "keyword.operator.heredoc.php,keyword.operator.nowdoc.php",
+            "settings": {
+                "foreground": "#ed8796"
+            }
+        },
+        {
+            "name": "python function decorator @",
+            "scope": "meta.function.decorator.python",
+            "settings": {
+                "foreground": "#8aadf4"
+            }
+        },
+        {
+            "name": "python function support",
+            "scope": "support.token.decorator.python,meta.function.decorator.identifier.python",
+            "settings": {
+                "foreground": "#91d7e3"
+            }
+        },
+        {
+            "name": "parameter function js/ts",
+            "scope": "function.parameter",
+            "settings": {
+                "foreground": "#cad3f5"
+            }
+        },
+        {
+            "name": "brace function",
+            "scope": "function.brace",
+            "settings": {
+                "foreground": "#cad3f5"
+            }
+        },
+        {
+            "name": "parameter function ruby cs",
+            "scope": "function.parameter.ruby, function.parameter.cs",
+            "settings": {
+                "foreground": "#cad3f5"
+            }
+        },
+        {
+            "name": "constant.language.symbol.ruby",
+            "scope": "constant.language.symbol.ruby",
+            "settings": {
+                "foreground": "#91d7e3"
+            }
+        },
+        {
+            "name": "rgb-value",
+            "scope": "rgb-value",
+            "settings": {
+                "foreground": "#91d7e3"
+            }
+        },
+        {
+            "name": "rgb value",
+            "scope": "inline-color-decoration rgb-value",
+            "settings": {
+                "foreground": "#eed49f"
+            }
+        },
+        {
+            "name": "rgb value less",
+            "scope": "less rgb-value",
+            "settings": {
+                "foreground": "#eed49f"
+            }
+        },
+        {
+            "name": "sass selector",
+            "scope": "selector.sass",
+            "settings": {
+                "foreground": "#8bd5ca"
+            }
+        },
+        {
+            "name": "ts primitive/builtin types",
+            "scope": "support.type.primitive.ts,support.type.builtin.ts,support.type.primitive.tsx,support.type.builtin.tsx",
+            "settings": {
+                "foreground": "#f5a97f"
+            }
+        },
+        {
+            "name": "block scope",
+            "scope": "block.scope.end,block.scope.begin",
+            "settings": {
+                "foreground": "#cad3f5"
+            }
+        },
+        {
+            "name": "cs storage type",
+            "scope": "storage.type.cs",
+            "settings": {
+                "foreground": "#f5a97f"
+            }
+        },
+        {
+            "name": "cs local variable",
+            "scope": "entity.name.variable.local.cs",
+            "settings": {
+                "foreground": "#cad3f5"
+            }
+        },
+        {
+            "scope": "token.info-token",
+            "settings": {
+                "foreground": "#8aadf4"
+            }
+        },
+        {
+            "scope": "token.warn-token",
+            "settings": {
+                "foreground": "#eed49f"
+            }
+        },
+        {
+            "scope": "token.error-token",
+            "settings": {
+                "foreground": "#f44747"
+            }
+        },
+        {
+            "scope": "token.debug-token",
+            "settings": {
+                "foreground": "#ed8796"
+            }
+        },
+        {
+            "name": "String interpolation",
+            "scope": [
+                "punctuation.definition.template-expression.begin",
+                "punctuation.definition.template-expression.end",
+                "punctuation.section.embedded"
+            ],
+            "settings": {
+                "foreground": "#ed8796"
+            }
+        },
+        {
+            "name": "Reset JavaScript string interpolation expression",
+            "scope": ["meta.template.expression"],
+            "settings": {
+                "foreground": "#cad3f5"
+            }
+        },
+        {
+            "name": "Import module JS",
+            "scope": ["keyword.operator.module"],
+            "settings": {
+                "foreground": "#ed8796"
+            }
+        },
+        {
+            "name": "js Flowtype",
+            "scope": ["support.type.type.flowtype"],
+            "settings": {
+                "foreground": "#8aadf4"
+            }
+        },
+        {
+            "name": "js Flow",
+            "scope": ["support.type.primitive"],
+            "settings": {
+                "foreground": "#f5a97f"
+            }
+        },
+        {
+            "name": "js class prop",
+            "scope": ["meta.property.object"],
+            "settings": {
+                "foreground": "#8bd5ca"
+            }
+        },
+        {
+            "name": "js func parameter",
+            "scope": ["variable.parameter.function.js"],
+            "settings": {
+                "foreground": "#8bd5ca"
+            }
+        },
+        {
+            "name": "js template literals begin",
+            "scope": ["keyword.other.template.begin"],
+            "settings": {
+                "foreground": "#a6da95"
+            }
+        },
+        {
+            "name": "js template literals end",
+            "scope": ["keyword.other.template.end"],
+            "settings": {
+                "foreground": "#a6da95"
+            }
+        },
+        {
+            "name": "js template literals variable braces begin",
+            "scope": ["keyword.other.substitution.begin"],
+            "settings": {
+                "foreground": "#a6da95"
+            }
+        },
+        {
+            "name": "js template literals variable braces end",
+            "scope": ["keyword.other.substitution.end"],
+            "settings": {
+                "foreground": "#a6da95"
+            }
+        },
+        {
+            "name": "go operator",
+            "scope": [
+                "keyword.operator.arithmetic.go",
+                "keyword.operator.address.go"
+            ],
+            "settings": {
+                "foreground": "#ed8796"
+            }
+        },
+        {
+            "name": "Go package name",
+            "scope": ["entity.name.package.go"],
+            "settings": {
+                "foreground": "#f5a97f"
+            }
+        },
+        {
+            "name": "elm prelude",
+            "scope": ["support.type.prelude.elm"],
+            "settings": {
+                "foreground": "#91d7e3"
+            }
+        },
+        {
+            "name": "elm constant",
+            "scope": ["support.constant.elm"],
+            "settings": {
+                "foreground": "#eed49f"
+            }
+        },
+        {
+            "name": "template literal",
+            "scope": ["punctuation.quasi.element"],
+            "settings": {
+                "foreground": "#ed8796"
+            }
+        },
+        {
+            "name": "html/pug (jade) escaped characters and entities",
+            "scope": ["constant.character.entity"],
+            "settings": {
+                "foreground": "#8bd5ca"
+            }
+        },
+        {
+            "name": "styling css pseudo-elements/classes to be able to differentiate from classes which are the same colour",
+            "scope": [
+                "entity.other.attribute-name.pseudo-element",
+                "entity.other.attribute-name.pseudo-class"
+            ],
+            "settings": {
+                "foreground": "#91d7e3"
+            }
+        },
+        {
+            "name": "Clojure globals",
+            "scope": ["entity.global.clojure"],
+            "settings": {
+                "foreground": "#f5a97f"
+            }
+        },
+        {
+            "name": "Clojure symbols",
+            "scope": ["meta.symbol.clojure"],
+            "settings": {
+                "foreground": "#8bd5ca"
+            }
+        },
+        {
+            "name": "Clojure constants",
+            "scope": ["constant.keyword.clojure"],
+            "settings": {
+                "foreground": "#91d7e3"
+            }
+        },
+        {
+            "name": "CoffeeScript Function Argument",
+            "scope": [
+                "meta.arguments.coffee",
+                "variable.parameter.function.coffee"
+            ],
+            "settings": {
+                "foreground": "#8bd5ca"
+            }
+        },
+        {
+            "name": "Ini Default Text",
+            "scope": ["source.ini"],
+            "settings": {
+                "foreground": "#a6da95"
+            }
+        },
+
+        {
+            "name": "Shell definition variables",
+            "scope": ["punctuation.definition.variable.shell"],
+            "settings": {
+                "foreground": "#8087a2"
+            }
+        },
+        {
+            "name": "Shell logical operators",
+            "scope": ["keyword.operator.logical.shell"],
+            "settings": {
+                "foreground": "#91d7e3"
+            }
+        },
+        {
+            "name": "Shell clauses",
+            "scope": ["meta.scope.case-clause-body.shell"],
+            "settings": {
+                "foreground": "#cad3f5"
+            }
+        },
+        {
+            "name": "Shell funcs",
+            "scope": ["meta.scope.group.shell"],
+            "settings": {
+                "foreground": "#8aadf4"
+            }
+        },
+        {
+            "name": "Shell interpolated cmds",
+            "scope": ["string.interpolated.dollar.shell"],
+            "settings": {
+                "foreground": "#eed49f"
+            }
+        },
+        {
+            "name": "Shell interpolated strings",
+            "scope": ["string.quoted.single.shell"],
+            "settings": {
+                "foreground": "#b7bdf8"
+            }
+        },
+        {
+            "name": "Shell pipe symbol",
+            "scope": ["keyword.operator.pipe.shell"],
+            "settings": {
+                "foreground": "#91d7e3"
+            }
+        },
+        {
+            "name": "Shell group definition",
+            "scope": ["punctuation.definition.group.shell"],
+            "settings": {
+                "foreground": "#8087a2"
+            }
+        },
+        {
+            "name": "Shell conditionals",
+            "scope": ["keyword.control.shell"],
+            "settings": {
+                "foreground": "#c6a0f6"
+            }
+        },
+        {
+            "name": "Shell opeartors and punct delimeters",
+            "scope": ["keyword.operator.list.shell"],
+            "settings": {
+                "foreground": "#8bd5ca"
+            }
+        },
+        {
+            "name": "Shell parenthesis",
+            "scope": ["punctuation.definition.logical-expression.shell"],
+            "settings": {
+                "foreground": "#8087a2"
+            }
+        },
+
+        {
+            "name": "Makefile prerequisities",
+            "scope": ["meta.scope.prerequisites.makefile"],
+            "settings": {
+                "foreground": "#8bd5ca"
+            }
+        },
+        {
+            "name": "Makefile text colour",
+            "scope": ["source.makefile"],
+            "settings": {
+                "foreground": "#f5a97f"
+            }
+        },
+        {
+            "name": "Groovy import names",
+            "scope": ["storage.modifier.import.groovy"],
+            "settings": {
+                "foreground": "#f5a97f"
+            }
+        },
+        {
+            "name": "Groovy Methods",
+            "scope": ["meta.method.groovy"],
+            "settings": {
+                "foreground": "#8aadf4"
+            }
+        },
+        {
+            "name": "Groovy Variables",
+            "scope": ["meta.definition.variable.name.groovy"],
+            "settings": {
+                "foreground": "#8bd5ca"
+            }
+        },
+        {
+            "name": "Groovy Inheritance",
+            "scope": ["meta.definition.class.inherited.classes.groovy"],
+            "settings": {
+                "foreground": "#a6da95"
+            }
+        },
+        {
+            "name": "HLSL Semantic",
+            "scope": ["support.variable.semantic.hlsl"],
+            "settings": {
+                "foreground": "#f5a97f"
+            }
+        },
+        {
+            "name": "HLSL Types",
+            "scope": [
+                "support.type.texture.hlsl",
+                "support.type.sampler.hlsl",
+                "support.type.object.hlsl",
+                "support.type.object.rw.hlsl",
+                "support.type.fx.hlsl",
+                "support.type.object.hlsl"
+            ],
+            "settings": {
+                "foreground": "#ed8796"
+            }
+        },
+        {
+            "name": "SQL Variables",
+            "scope": ["text.variable", "text.bracketed"],
+            "settings": {
+                "foreground": "#8bd5ca"
+            }
+        },
+        {
+            "name": "types",
+            "scope": ["support.type.swift", "support.type.vb.asp"],
+            "settings": {
+                "foreground": "#f5a97f"
+            }
+        },
+        {
+            "name": "heading 1, keyword",
+            "scope": ["entity.name.function.xi"],
+            "settings": {
+                "foreground": "#8aadf4"
+            }
+        },
+        {
+            "name": "heading 2, callable",
+            "scope": ["entity.name.class.xi"],
+            "settings": {
+                "foreground": "#91d7e3"
+            }
+        },
+        {
+            "name": "heading 3, property",
+            "scope": ["constant.character.character-class.regexp.xi"],
+            "settings": {
+                "foreground": "#8bd5ca"
+            }
+        },
+        {
+            "name": "heading 4, type, class, interface",
+            "scope": ["constant.regexp.xi"],
+            "settings": {
+                "foreground": "#ed8796"
+            }
+        },
+        {
+            "name": "heading 5, enums, preprocessor, constant, decorator",
+            "scope": ["keyword.control.xi"],
+            "settings": {
+                "foreground": "#91d7e3"
+            }
+        },
+        {
+            "name": "heading 6, number",
+            "scope": ["invalid.xi"],
+            "settings": {
+                "foreground": "#cad3f5"
+            }
+        },
+        {
+            "name": "string",
+            "scope": ["beginning.punctuation.definition.quote.markdown.xi"],
+            "settings": {
+                "foreground": "#a6da95"
+            }
+        },
+        {
+            "name": "comments",
+            "scope": ["beginning.punctuation.definition.list.markdown.xi"],
+            "settings": {
+                "foreground": "#6e738d"
+            }
+        },
+        {
+            "name": "link",
+            "scope": ["constant.character.xi"],
+            "settings": {
+                "foreground": "#8aadf4"
+            }
+        },
+        {
+            "name": "accent",
+            "scope": ["accent.xi"],
+            "settings": {
+                "foreground": "#8aadf4"
+            }
+        },
+        {
+            "name": "wikiword",
+            "scope": ["wikiword.xi"],
+            "settings": {
+                "foreground": "#eed49f"
+            }
+        },
+        {
+            "name": "language operators like '+', '-' etc",
+            "scope": ["constant.other.color.rgb-value.xi"],
+            "settings": {
+                "foreground": "#ffffff"
+            }
+        },
+        {
+            "name": "elements to dim",
+            "scope": ["punctuation.definition.tag.xi"],
+            "settings": {
+                "foreground": "#6e738d"
+            }
+        },
+        {
+            "name": "Markdown underscore-style headers",
+            "scope": [
+                "entity.name.label.cs",
+                "markup.heading.setext.1.markdown",
+                "markup.heading.setext.2.markdown"
+            ],
+            "settings": {
+                "foreground": "#8bd5ca"
+            }
+        },
+        {
+            "name": "meta.brace.square",
+            "scope": [" meta.brace.square"],
+            "settings": {
+                "foreground": "#cad3f5"
+            }
+        },
+        {
+            "name": "Comments",
+            "scope": "comment, punctuation.definition.comment",
+            "settings": {
+                "fontStyle": "italic",
+                "foreground": "#6e738d"
+            }
+        },
+        {
+            "name": "[VSCODE-CUSTOM] Markdown Quote",
+            "scope": "markup.quote.markdown",
+            "settings": {
+                "foreground": "#6e738d"
+            }
+        },
+        {
+            "name": "punctuation.definition.block.sequence.item.yaml",
+            "scope": "punctuation.definition.block.sequence.item.yaml",
+            "settings": {
+                "foreground": "#cad3f5"
+            }
+        },
+        {
+            "scope": ["constant.language.symbol.elixir"],
+            "settings": {
+                "foreground": "#91d7e3"
+            }
+        },
+        {
+            "name": "js/ts italic",
+            "scope": "entity.other.attribute-name.js,entity.other.attribute-name.ts,entity.other.attribute-name.jsx,entity.other.attribute-name.tsx,variable.parameter,variable.language.super",
+            "settings": {
+                "fontStyle": "italic"
+            }
+        },
+        {
+            "name": "comment",
+            "scope": "comment.line.double-slash,comment.block.documentation",
+            "settings": {
+                "fontStyle": "italic"
+            }
+        },
+        {
+            "name": "python keyword import",
+            "scope": "keyword.control.import.python",
+            "settings": {
+                "foreground": "#8bd5ca",
+                "fontStyle": "italic"
+            }
+        },
+        {
+            "name": "python keyword flow",
+            "scope": "keyword.control.flow.python",
+            "settings": {
+                "foreground": "#c6a0f6",
+                "fontStyle": "bold"
+            }
+        },
+        {
+            "name": "python storage type",
+            "scope": "storage.type.function.python",
+            "settings": {
+                "foreground": "#ee99a0",
+                "fontStyle": "italic"
+            }
+        },
+        {
+            "name": "markup.italic.markdown",
+            "scope": "markup.italic.markdown",
+            "settings": {
+                "fontStyle": "italic"
+            }
+        }
+    ],
+    "colors": {
+        "foreground": "#cad3f5",
+        "focusBorder": "#8aadf4",
+        "selection.background": "#6e738d",
+        "scrollbar.shadow": "#24273a",
+        "activityBar.foreground": "#cad3f5",
+        "activityBar.background": "#24273a",
+        "activityBar.inactiveForeground": "#cad3f55a",
+        "activityBarBadge.foreground": "#24273a",
+        "activityBarBadge.background": "#8aadf4",
+        "sideBar.background": "#1e2030",
+        "sideBar.foreground": "#cad3f5",
+        "sideBarSectionHeader.background": "#00000000",
+        "sideBarSectionHeader.foreground": "#cad3f5",
+        "sideBarTitle.foreground": "#cad3f5",
+        "list.inactiveSelectionBackground": "#24273a",
+        "list.inactiveSelectionForeground": "#cad3f5",
+        "list.hoverBackground": "#24273a",
+        "list.hoverForeground": "#cad3f5",
+        "list.activeSelectionBackground": "#5b6078",
+        "list.activeSelectionForeground": "#cad3f5",
+        "tree.indentGuidesStroke": "#6e738d",
+        "list.dropBackground": "#24273a",
+        "list.highlightForeground": "#8aadf4",
+        "list.focusBackground": "#494d64",
+        "list.focusForeground": "#cad3f5",
+        "listFilterWidget.background": "#494d64",
+        "listFilterWidget.outline": "#00000000",
+        "listFilterWidget.noMatchesOutline": "#ed8796",
+        "statusBar.foreground": "#cad3f5",
+        "statusBar.background": "#494d64",
+        "statusBarItem.hoverBackground": "#ffffff1f",
+        "statusBar.debuggingBackground": "#ed8796",
+        "statusBar.debuggingForeground": "#494d64",
+        "statusBar.noFolderBackground": "#c6a0f6",
+        "statusBar.noFolderForeground": "#494d64",
+        "statusBarItem.remoteBackground": "#a6da95",
+        "statusBarItem.remoteForeground": "#494d64",
+        "titleBar.activeBackground": "#24273a",
+        "titleBar.activeForeground": "#cad3f5",
+        "titleBar.inactiveBackground": "#24273a91",
+        "titleBar.inactiveForeground": "#cad3f580",
+        "titleBar.border": "#00000000",
+        "menubar.selectionForeground": "#cad3f5",
+        "menubar.selectionBackground": "#494d64",
+        "menu.foreground": "#cad3f5",
+        "menu.background": "#494d64",
+        "menu.selectionForeground": "#cad3f5",
+        "menu.selectionBackground": "#5b6078",
+        "menu.selectionBorder": "#00000000",
+        "menu.separatorBackground": "#cad3f5",
+        "menu.border": "#00000085",
+        "button.background": "#5b6078",
+        "button.foreground": "#cad3f5",
+        "button.hoverBackground": "#494d64",
+        "button.secondaryForeground": "#cad3f5",
+        "button.secondaryBackground": "#494d64",
+        "button.secondaryHoverBackground": "#24273a",
+        "input.background": "#24273a",
+        "input.border": "#00000000",
+        "input.foreground": "#cad3f5",
+        "inputOption.activeBackground": "#8aadf426",
+        "inputOption.activeBorder": "#8aadf400",
+        "inputOption.activeForeground": "#cad3f5",
+        "input.placeholderForeground": "#cad3f570",
+        "textLink.foreground": "#8aadf4",
+        "editor.background": "#24273a",
+        "editor.foreground": "#cad3f5",
+        "editorLineNumber.foreground": "#8087a2",
+        "editorCursor.foreground": "#f4dbd6",
+        "editorCursor.background": "#24273a",
+        "editor.selectionBackground": "#5b6078",
+        "editor.inactiveSelectionBackground": "#FFFFFF20",
+        "editorWhitespace.foreground": "#939ab718",
+        "editor.selectionHighlightBackground": "#939ab75e",
+        "editor.selectionHighlightBorder": "#91d7e330",
+        "editor.findMatchBackground": "#5b6078",
+        "editor.findMatchBorder": "#8aadf46a",
+        "editor.findMatchHighlightBackground": "#f5a97f5e",
+        "editor.findMatchHighlightBorder": "#ffffff00",
+        "editor.findRangeHighlightBackground": "#5b607848",
+        "editor.findRangeHighlightBorder": "#ffffff00",
+        "editor.rangeHighlightBackground": "#8aadf43c",
+        "editor.rangeHighlightBorder": "#ffffff00",
+        "editor.hoverHighlightBackground": "#8aadf43c",
+        "editor.wordHighlightStrongBackground": "#5b6078",
+        "editor.wordHighlightBackground": "#575757b8",
+        "editor.lineHighlightBackground": "#ffffff0A",
+        "editor.lineHighlightBorder": "#24273a",
+        "editorLineNumber.activeForeground": "#a6da95",
+        "editorLink.activeForeground": "#8aadf4",
+        "editorIndentGuide.background": "#494d64",
+        "editorIndentGuide.activeBackground": "#5b6078",
+        "editorRuler.foreground": "#5b6078",
+        "editorBracketMatch.background": "#939ab714",
+        "editorBracketMatch.border": "#939ab7",
+        "editor.foldBackground": "#8aadf442",
+        "editorOverviewRuler.background": "#25252500",
+        "editorOverviewRuler.border": "#FFFFFF0F",
+        "editorError.foreground": "#ed8796",
+        "editorError.background": "#B73A3400",
+        "editorError.border": "#ffffff00",
+        "editorWarning.foreground": "#eed49f",
+        "editorWarning.background": "#A9904000",
+        "editorWarning.border": "#ffffff00",
+        "editorInfo.foreground": "#8aadf4",
+        "editorInfo.background": "#4490BF00",
+        "editorInfo.border": "#4490BF00",
+        "editorGutter.background": "#24273a",
+        "editorGutter.modifiedBackground": "#91d7e3",
+        "editorGutter.addedBackground": "#a6da95",
+        "editorGutter.deletedBackground": "#ed8796",
+        "editorGutter.foldingControlForeground": "#939ab7",
+        "editorCodeLens.foreground": "#8087a2",
+        "editorGroup.border": "#5b6078",
+        // test
+        "diffEditor.insertedTextBackground": "#a6da9518",
+        "diffEditor.removedTextBackground": "#ed87961c",
+        "diffEditor.border": "#5b6078",
+        "panel.background": "#24273a",
+        "panel.border": "#5b6078",
+        "panelTitle.activeBorder": "#cad3f5",
+        "panelTitle.activeForeground": "#cad3f5",
+        "panelTitle.inactiveForeground": "#cad3f5ad",
+        "badge.background": "#494d64",
+        "badge.foreground": "#cad3f5",
+        "terminal.foreground": "#cad3f5",
+        "terminal.selectionBackground": "#5b607834",
+        "terminalCursor.background": "#24273a",
+        "terminalCursor.foreground": "#f4dbd6",
+        "terminal.border": "#5b6078",
+        "terminal.ansiBlack": "#6e738d",
+        "terminal.ansiBlue": "#8aadf4",
+        "terminal.ansiBrightBlack": "#8087a2",
+        "terminal.ansiBrightBlue": "#8aadf4",
+        "terminal.ansiBrightCyan": "#91d7e3",
+        "terminal.ansiBrightGreen": "#a6da95",
+        "terminal.ansiBrightMagenta": "#f5bde6",
+        "terminal.ansiBrightRed": "#ed8796",
+        "terminal.ansiBrightWhite": "#cad3f5",
+        "terminal.ansiBrightYellow": "#eed49f",
+        "terminal.ansiCyan": "#91d7e3",
+        "terminal.ansiGreen": "#a6da95",
+        "terminal.ansiMagenta": "#f5bde6",
+        "terminal.ansiRed": "#ed8796",
+        "terminal.ansiWhite": "#939ab7",
+        "terminal.ansiYellow": "#eed49f",
+        "breadcrumb.background": "#24273a",
+        "breadcrumb.foreground": "#cad3f5cd",
+        "breadcrumb.focusForeground": "#cad3f5",
+        "editorGroupHeader.tabsBackground": "#24273a",
+        "tab.activeForeground": "#cad3f5",
+        "tab.border": "#494d64",
+        "tab.activeBackground": "#24273a",
+        "tab.activeBorder": "#00000000",
+        "tab.activeBorderTop": "#00000000",
+        "tab.inactiveBackground": "#494d64",
+        "tab.inactiveForeground": "#cad3f564",
+        "scrollbarSlider.background": "#5b60787e",
+        "scrollbarSlider.hoverBackground": "#6e738d",
+        "scrollbarSlider.activeBackground": "#bfbfbf66",
+        "progressBar.background": "#8aadf4",
+        "widget.shadow": "#00000080",
+        "editorWidget.foreground": "#cad3f5",
+        "editorWidget.background": "#24273a",
+        "editorWidget.resizeBorder": "#5b6078",
+        "pickerGroup.border": "#8aadf4",
+        "pickerGroup.foreground": "#8aadf4",
+        "debugToolBar.background": "#494d64",
+        "debugToolBar.border": "#5b6078",
+        "notifications.foreground": "#cad3f5",
+        "notifications.background": "#494d64",
+        "notificationToast.border": "#5b6078",
+        "notificationsErrorIcon.foreground": "#ed8796",
+        "notificationsWarningIcon.foreground": "#eed49f",
+        "notificationsInfoIcon.foreground": "#8aadf4",
+        "notificationCenter.border": "#5b6078",
+        "notificationCenterHeader.foreground": "#cad3f5",
+        "notificationCenterHeader.background": "#24273a",
+        "notifications.border": "#494d64",
+        "gitDecoration.addedResourceForeground": "#a6da95",
+        "gitDecoration.conflictingResourceForeground": "#c6a0f6",
+        "gitDecoration.deletedResourceForeground": "#ed8796",
+        "gitDecoration.ignoredResourceForeground": "#6e738d",
+        "gitDecoration.modifiedResourceForeground": "#eed49f",
+        "gitDecoration.stageDeletedResourceForeground": "#ed8796",
+        "gitDecoration.stageModifiedResourceForeground": "#eed49f",
+        "gitDecoration.submoduleResourceForeground": "#8aadf4",
+        "gitDecoration.untrackedResourceForeground": "#a6da95",
+        "editorMarkerNavigation.background": "#494d64",
+        "editorMarkerNavigationError.background": "#ed8796",
+        "editorMarkerNavigationWarning.background": "#eed49f",
+        "editorMarkerNavigationInfo.background": "#8aadf4",
+        "merge.currentHeaderBackground": "#158472",
+        "merge.currentContentBackground": "#27403B",
+        "merge.incomingHeaderBackground": "#395F8F",
+        "merge.incomingContentBackground": "#243A5E",
+        "merge.commonHeaderBackground": "#5b6078",
+        "merge.commonContentBackground": "#494d64",
+        "editorSuggestWidget.background": "#494d64",
+        "editorSuggestWidget.border": "#5b6078",
+        "editorSuggestWidget.foreground": "#cad3f5",
+        "editorSuggestWidget.highlightForeground": "#8aadf4",
+        "editorSuggestWidget.selectedBackground": "#5b6078",
+        "editorHoverWidget.foreground": "#cad3f5",
+        "editorHoverWidget.background": "#494d64",
+        "editorHoverWidget.border": "#5b6078",
+        "peekView.border": "#8aadf4",
+        "peekViewEditor.background": "#494d64",
+        "peekViewEditorGutter.background": "#494d64",
+        "peekViewEditor.matchHighlightBackground": "#f5a97f40",
+        "peekViewEditor.matchHighlightBorder": "#f5a97f",
+        "peekViewResult.background": "#494d64",
+        "peekViewResult.fileForeground": "#cad3f5",
+        "peekViewResult.lineForeground": "#cad3f5",
+        "peekViewResult.matchHighlightBackground": "#f5a97f40",
+        "peekViewResult.selectionBackground": "#5b6078",
+        "peekViewResult.selectionForeground": "#cad3f5",
+        "peekViewTitle.background": "#24273a",
+        "peekViewTitleDescription.foreground": "#ccccccb3",
+        "peekViewTitleLabel.foreground": "#cad3f5",
+        "icon.foreground": "#cad3f5",
+        "checkbox.background": "#24273a",
+        "checkbox.foreground": "#cad3f5",
+        "checkbox.border": "#00000000",
+        "dropdown.background": "#24273a",
+        "dropdown.foreground": "#cad3f5",
+        "dropdown.border": "#00000000",
+        "minimapGutter.addedBackground": "#a6da95",
+        "minimapGutter.modifiedBackground": "#91d7e3",
+        "minimapGutter.deletedBackground": "#ed8796",
+        "minimap.findMatchHighlight": "#5b6078",
+        "minimap.selectionHighlight": "#5b6078",
+        "minimap.errorHighlight": "#ed8796",
+        "minimap.warningHighlight": "#eed49f",
+        "minimap.background": "#24273a",
+        "sideBar.dropBackground": "#1e2030",
+        "editorGroup.emptyBackground": "#24273a",
+        "panelSection.border": "#5b6078",
+        "statusBarItem.activeBackground": "#FFFFFF25",
+        "settings.headerForeground": "#cad3f5",
+        "settings.focusedRowBackground": "#ffffff07",
+        "walkThrough.embeddedEditorBackground": "#00000050",
+        "breadcrumb.activeSelectionForeground": "#cad3f5",
+        "editorGutter.commentRangeForeground": "#939ab7",
+        "debugExceptionWidget.background": "#494d64",
+        "debugExceptionWidget.border": "#5b6078",
+        "activitusbar.inactiveColour": "#000000",
+        "activitusbar.activeColour": "#000000"
+    }
+}

--- a/themes/Catppuccin-mocha-color-theme.json
+++ b/themes/Catppuccin-mocha-color-theme.json
@@ -1,5 +1,5 @@
 {
-    "name": "Catppuccin",
+    "name": "Catppuccin Mocha",
     "type": "dark",
     "semanticHighlighting": true,
     "semanticTokenColors": {
@@ -7,10 +7,10 @@
             "foreground": "#89dceb"
         },
         "variable.constant": {
-            "foreground": "#fae3b0"
+            "foreground": "#f9e2af"
         },
         "variable.defaultLibrary": {
-            "foreground": "#f8bd96"
+            "foreground": "#fab387"
         }
     },
     "tokenColors": [
@@ -18,14 +18,14 @@
             "name": "All variable",
             "scope": ["variable.language", "variable.other"],
             "settings": {
-                "foreground": "#d9e0ee"
+                "foreground": "#f2cdcd"
             }
         },
         {
             "name": "All function",
             "scope": ["entity.name.function", "support.function"],
             "settings": {
-                "foreground": "#96cdfb",
+                "foreground": "#89b4fa",
                 "fontStyle": "italic"
             }
         },
@@ -36,7 +36,7 @@
                 "variable.parameter.function-call"
             ],
             "settings": {
-                "foreground": "#f5e0dc",
+                "foreground": "#f5c2e7",
                 "fontStyle": "italic"
             }
         },
@@ -44,7 +44,7 @@
             "name": "All numeric",
             "scope": ["constant.numeric.decimal", "constant.numeric.integer"],
             "settings": {
-                "foreground": "#f8bd96",
+                "foreground": "#fab387",
                 "fontStyle": "bold"
             }
         },
@@ -52,7 +52,7 @@
             "name": "All types",
             "scope": "entity.name.type",
             "settings": {
-                "foreground": "#fae3b0"
+                "foreground": "#89b4fa"
             }
         },
         {
@@ -67,7 +67,7 @@
                 "keyword.control.case"
             ],
             "settings": {
-                "foreground": "#ddb6f2",
+                "foreground": "#f38ba8",
                 "fontStyle": "bold"
             }
         },
@@ -79,14 +79,14 @@
                 "punctuation.definition"
             ],
             "settings": {
-                "foreground": "#988ba2"
+                "foreground": "#7f849c"
             }
         },
         {
             "name": "All punctuation delimeters",
             "scope": "punctuation.semi",
             "settings": {
-                "foreground": "#b5e8e0"
+                "foreground": "#94e2d5"
             }
         },
         {
@@ -116,7 +116,7 @@
             "name": "All built-in constants",
             "scope": "constant.language",
             "settings": {
-                "foreground": "#c9cbff",
+                "foreground": "#b4befe",
                 "fontStyle": "italic"
             }
         },
@@ -124,42 +124,42 @@
             "name": "All constants",
             "scope": "constant.other",
             "settings": {
-                "foreground": "#f8bd96"
+                "foreground": "#fab387"
             }
         },
         {
             "name": "JSON quoted string",
             "scope": "source.json meta.structure.dictionary.json > string.quoted.json",
             "settings": {
-                "foreground": "#b5e8e0"
+                "foreground": "#94e2d5"
             }
         },
         {
             "name": "JSON punctuation string",
             "scope": "source.json meta.structure.dictionary.json > string.quoted.json > punctuation.string",
             "settings": {
-                "foreground": "#b5e8e0"
+                "foreground": "#94e2d5"
             }
         },
         {
             "name": "JSON punct structure",
             "scope": "source.json meta.structure.dictionary.json > value.json > string.quoted.json,source.json meta.structure.array.json > value.json > string.quoted.json,source.json meta.structure.dictionary.json > value.json > string.quoted.json > punctuation,source.json meta.structure.array.json > value.json > string.quoted.json > punctuation",
             "settings": {
-                "foreground": "#abe9b3"
+                "foreground": "#a6e3a1"
             }
         },
         {
             "name": "JSON property name",
             "scope": "support.type.property-name.json.comments",
             "settings": {
-                "foreground": "#96cdfb"
+                "foreground": "#89b4fa"
             }
         },
         {
             "name": "JSON constants",
             "scope": "constant.language.json.comments",
             "settings": {
-                "foreground": "#f8bd96"
+                "foreground": "#fab387"
             }
         },
         {
@@ -169,7 +169,7 @@
                 "punctuation.separator.array.json.comments"
             ],
             "settings": {
-                "foreground": "#b5e8e0"
+                "foreground": "#94e2d5"
             }
         },
         {
@@ -181,7 +181,7 @@
                 "punctuation.definition.array.end.json.comments"
             ],
             "settings": {
-                "foreground": "#988ba2"
+                "foreground": "#9399b2"
             }
         },
         {
@@ -195,14 +195,14 @@
             "name": "JSON property name [VSCODE-CUSTOM]",
             "scope": "support.type.property-name.json",
             "settings": {
-                "foreground": "#b5e8e0"
+                "foreground": "#94e2d5"
             }
         },
         {
             "name": "[VSCODE-CUSTOM] JSON Punctuation for Property Name",
             "scope": "support.type.property-name.json punctuation",
             "settings": {
-                "foreground": "#b5e8e0"
+                "foreground": "#94e2d5"
             }
         },
 
@@ -210,42 +210,42 @@
             "name": "unison punctuation",
             "scope": "punctuation.definition.delayed.unison,punctuation.definition.list.begin.unison,punctuation.definition.list.end.unison,punctuation.definition.ability.begin.unison,punctuation.definition.ability.end.unison,punctuation.operator.assignment.as.unison,punctuation.separator.pipe.unison,punctuation.separator.delimiter.unison,punctuation.definition.hash.unison",
             "settings": {
-                "foreground": "#b5e8e0"
+                "foreground": "#94e2d5"
             }
         },
         {
             "name": "haskell variable generic-type",
             "scope": "variable.other.generic-type.haskell",
             "settings": {
-                "foreground": "#f28fad"
+                "foreground": "#f38ba8"
             }
         },
         {
             "name": "haskell storage type",
             "scope": "storage.type.haskell",
             "settings": {
-                "foreground": "#fae3b0"
+                "foreground": "#f9e2af"
             }
         },
         {
             "name": "support.variable.magic.python",
             "scope": "support.variable.magic.python",
             "settings": {
-                "foreground": "#d9e0ee"
+                "foreground": "#cdd6f4"
             }
         },
         {
             "name": "punctuation.separator.parameters.python",
             "scope": "punctuation.separator.period.python,punctuation.separator.element.python,punctuation.parenthesis.begin.python,punctuation.parenthesis.end.python",
             "settings": {
-                "foreground": "#d9e0ee"
+                "foreground": "#cdd6f4"
             }
         },
         {
             "name": "variable.parameter.function.language.special.self.python",
             "scope": "variable.parameter.function.language.special.self.python",
             "settings": {
-                "foreground": "#f8bd96"
+                "foreground": "#fab387"
             }
         },
 
@@ -253,28 +253,28 @@
             "name": "Rust modifier",
             "scope": "storage.modifier.lifetime.rust",
             "settings": {
-                "foreground": "#d9e0ee"
+                "foreground": "#cdd6f4"
             }
         },
         {
             "name": "Rust types",
             "scope": "entity.name.type.rust",
             "settings": {
-                "foreground": "#fae3b0"
+                "foreground": "#f9e2af"
             }
         },
         {
             "name": "Rust functions std",
             "scope": "support.function.std.rust",
             "settings": {
-                "foreground": "#96cdfb"
+                "foreground": "#89b4fa"
             }
         },
         {
             "name": "Rust functions",
             "scope": "entity.name.function.rust",
             "settings": {
-                "foreground": "#96cdfb",
+                "foreground": "#89b4fa",
                 "fontStyle": "italic"
             }
         },
@@ -282,14 +282,14 @@
             "name": "Rust function keyword",
             "scope": "keyword.other.fn.rust",
             "settings": {
-                "foreground": "#e8a2af"
+                "foreground": "#eba0ac"
             }
         },
         {
             "name": "Rust conditionals",
             "scope": "keyword.control.rust",
             "settings": {
-                "foreground": "#ddb6f2",
+                "foreground": "#cba6f7",
                 "fontStyle": "bold"
             }
         },
@@ -302,7 +302,7 @@
                 "punctuation.brackets.attribute.rust"
             ],
             "settings": {
-                "foreground": "#988ba2"
+                "foreground": "#7f849c"
             }
         },
         {
@@ -316,7 +316,7 @@
             "name": "Rust punctuation delimeters",
             "scope": "punctuation.semi.rust",
             "settings": {
-                "foreground": "#b5e8e0"
+                "foreground": "#94e2d5"
             }
         },
         {
@@ -337,7 +337,7 @@
             "name": "Rust operator namespaces",
             "scope": "keyword.operator.namespace.rust",
             "settings": {
-                "foreground": "#b5e8e0"
+                "foreground": "#94e2d5"
             }
         },
         {
@@ -347,7 +347,7 @@
                 "keyword.operator.attribute.inner.rust"
             ],
             "settings": {
-                "foreground": "#b5e8e0",
+                "foreground": "#94e2d5",
                 "fontStyle": "bold"
             }
         },
@@ -355,28 +355,28 @@
             "name": "Rust math logic",
             "scope": "constant.numeric.decimal.rust",
             "settings": {
-                "foreground": "#f8bd96"
+                "foreground": "#fab387"
             }
         },
         {
             "name": "Rust constants",
             "scope": "support.constant.core.rust",
             "settings": {
-                "foreground": "#fae3b0"
+                "foreground": "#f9e2af"
             }
         },
         {
             "name": "Rust entity name",
             "scope": "entity.name.lifetime.rust",
             "settings": {
-                "foreground": "#f8bd96"
+                "foreground": "#fab387"
             }
         },
         {
             "name": "Rust variable",
             "scope": ["variable.language.rust", "variable.other.rust"],
             "settings": {
-                "foreground": "#d9e0ee",
+                "foreground": "#cdd6f4",
                 "fontStyle": "italic"
             }
         },
@@ -384,14 +384,14 @@
             "name": "Rust misc operators",
             "scope": "keyword.operator.misc.rust",
             "settings": {
-                "foreground": "#d9e0ee"
+                "foreground": "#cdd6f4"
             }
         },
         {
             "name": "Rust sigil operator",
             "scope": "keyword.operator.sigil.rust",
             "settings": {
-                "foreground": "#f28fad"
+                "foreground": "#f38ba8"
             }
         },
 
@@ -407,7 +407,7 @@
             "name": "Lua numeric",
             "scope": "constant.numeric.integer.lua",
             "settings": {
-                "foreground": "#f8bd96",
+                "foreground": "#fab387",
                 "fontStyle": "bold"
             }
         },
@@ -415,7 +415,7 @@
             "name": "Lua other vars",
             "scope": "variable.other.lua",
             "settings": {
-                "foreground": "#c9cbff",
+                "foreground": "#b4befe",
                 "fontStyle": "italic"
             }
         },
@@ -426,7 +426,7 @@
                 "punctuation.definition.parameters.begin.lua"
             ],
             "settings": {
-                "foreground": "#988ba2"
+                "foreground": "#7f849c"
             }
         },
 
@@ -434,7 +434,7 @@
             "name": "C++ Puct Delimeters",
             "scope": "punctuation.terminator.statement.cpp",
             "settings": {
-                "foreground": "#b5e8e0",
+                "foreground": "#94e2d5",
                 "fontStyle": "bold"
             }
         },
@@ -454,7 +454,7 @@
             "name": "C++ function",
             "scope": "meta.function.c,meta.function.cpp",
             "settings": {
-                "foreground": "#b5e8e0"
+                "foreground": "#94e2d5"
             }
         },
 
@@ -465,7 +465,7 @@
                 "entity.name.function.definition.special.member.destructor"
             ],
             "settings": {
-                "foreground": "#c9cbff"
+                "foreground": "#b4befe"
             }
         },
         {
@@ -476,7 +476,7 @@
                 "punctuation.definition.directive"
             ],
             "settings": {
-                "foreground": "#b5e8e0",
+                "foreground": "#94e2d5",
                 "fontStyle": "italic"
             }
         },
@@ -491,7 +491,7 @@
                 "keyword.control.directive.endif.cpp punctuation.definition.directive.cpp"
             ],
             "settings": {
-                "foreground": "#f28fad"
+                "foreground": "#f38ba8"
             }
         },
         {
@@ -512,7 +512,7 @@
                 "storage.modifier.reference.cpp"
             ],
             "settings": {
-                "foreground": "#b5e8e0"
+                "foreground": "#94e2d5"
             }
         },
         {
@@ -526,7 +526,7 @@
                 "keyword.control.case"
             ],
             "settings": {
-                "foreground": "#ddb6f2",
+                "foreground": "#cba6f7",
                 "fontStyle": "bold"
             }
         },
@@ -551,14 +551,14 @@
                 "punctuation.section.parameters.end.bracket.round.c"
             ],
             "settings": {
-                "foreground": "#d9e0ee"
+                "foreground": "#cdd6f4"
             }
         },
         {
             "name": "C++ storage type modifier",
             "scope": "storage.type.built-in.primitive.cpp",
             "settings": {
-                "foreground": "#fae3b0"
+                "foreground": "#f9e2af"
             }
         },
         {
@@ -569,70 +569,70 @@
                 "entity.name.scope-resolution.function.definition"
             ],
             "settings": {
-                "foreground": "#f8bd96"
+                "foreground": "#fab387"
             }
         },
         {
             "name": "support.constant.edge",
             "scope": "support.constant.edge",
             "settings": {
-                "foreground": "#f28fad"
+                "foreground": "#f38ba8"
             }
         },
         {
             "name": "regexp constant character-class",
             "scope": "constant.other.character-class.regexp",
             "settings": {
-                "foreground": "#b5e8e0"
+                "foreground": "#94e2d5"
             }
         },
         {
             "name": "regexp operator.quantifier",
             "scope": "keyword.operator.quantifier.regexp",
             "settings": {
-                "foreground": "#fae3b0"
+                "foreground": "#f9e2af"
             }
         },
         {
             "name": "punctuation.definition",
             "scope": "punctuation.definition.string.begin,punctuation.definition.string.end",
             "settings": {
-                "foreground": "#abe9b3"
+                "foreground": "#a6e3a1"
             }
         },
         {
             "name": "Comment Markup Link",
             "scope": "comment markup.link",
             "settings": {
-                "foreground": "#6e6c7e"
+                "foreground": "#6c7086"
             }
         },
         {
             "name": "markup diff",
             "scope": "markup.changed.diff",
             "settings": {
-                "foreground": "#f8bd96"
+                "foreground": "#fab387"
             }
         },
         {
             "name": "diff",
             "scope": "meta.diff.header.from-file,meta.diff.header.to-file,punctuation.definition.from-file.diff,punctuation.definition.to-file.diff",
             "settings": {
-                "foreground": "#96cdfb"
+                "foreground": "#89b4fa"
             }
         },
         {
             "name": "inserted.diff",
             "scope": "markup.inserted.diff",
             "settings": {
-                "foreground": "#abe9b3"
+                "foreground": "#a6e3a1"
             }
         },
         {
             "name": "deleted.diff",
             "scope": "markup.deleted.diff",
             "settings": {
-                "foreground": "#b5e8e0"
+                "foreground": "#94e2d5"
             }
         },
         {
@@ -647,7 +647,7 @@
                 "markup.fenced_code.block"
             ],
             "settings": {
-                "foreground": "#b5e8e0",
+                "foreground": "#94e2d5",
                 "fontStyle": "italic"
             }
         },
@@ -655,35 +655,35 @@
             "name": "js/ts punctuation separator key-value",
             "scope": "punctuation.separator.key-value",
             "settings": {
-                "foreground": "#d9e0ee"
+                "foreground": "#cdd6f4"
             }
         },
         {
             "name": "js/ts import keyword",
             "scope": "keyword.operator.expression.import",
             "settings": {
-                "foreground": "#96cdfb"
+                "foreground": "#89b4fa"
             }
         },
         {
             "name": "math js/ts",
             "scope": "support.constant.math",
             "settings": {
-                "foreground": "#f8bd96"
+                "foreground": "#fab387"
             }
         },
         {
             "name": "math property js/ts",
             "scope": "support.constant.property.math",
             "settings": {
-                "foreground": "#fae3b0"
+                "foreground": "#f9e2af"
             }
         },
         {
             "name": "js/ts variable.other.constant",
             "scope": "variable.other.constant",
             "settings": {
-                "foreground": "#d9e0ee"
+                "foreground": "#cdd6f4"
             }
         },
         {
@@ -693,49 +693,49 @@
                 "storage.type.object.array.java"
             ],
             "settings": {
-                "foreground": "#f8bd96"
+                "foreground": "#fab387"
             }
         },
         {
             "name": "java source",
             "scope": "source.java",
             "settings": {
-                "foreground": "#b5e8e0"
+                "foreground": "#94e2d5"
             }
         },
         {
             "name": "java modifier.import",
             "scope": "punctuation.section.block.begin.java,punctuation.section.block.end.java,punctuation.definition.method-parameters.begin.java,punctuation.definition.method-parameters.end.java,meta.method.identifier.java,punctuation.section.method.begin.java,punctuation.section.method.end.java,punctuation.terminator.java,punctuation.section.class.begin.java,punctuation.section.class.end.java,punctuation.section.inner-class.begin.java,punctuation.section.inner-class.end.java,meta.method-call.java,punctuation.section.class.begin.bracket.curly.java,punctuation.section.class.end.bracket.curly.java,punctuation.section.method.begin.bracket.curly.java,punctuation.section.method.end.bracket.curly.java,punctuation.separator.period.java,punctuation.bracket.angle.java,punctuation.definition.annotation.java,meta.method.body.java",
             "settings": {
-                "foreground": "#d9e0ee"
+                "foreground": "#cdd6f4"
             }
         },
         {
             "name": "java modifier.import",
             "scope": "meta.method.java",
             "settings": {
-                "foreground": "#96cdfb"
+                "foreground": "#89b4fa"
             }
         },
         {
             "name": "java modifier.import",
             "scope": "storage.modifier.import.java,storage.type.java,storage.type.generic.java",
             "settings": {
-                "foreground": "#f8bd96"
+                "foreground": "#fab387"
             }
         },
         {
             "name": "java instanceof",
             "scope": "keyword.operator.instanceof.java",
             "settings": {
-                "foreground": "#f28fad"
+                "foreground": "#f38ba8"
             }
         },
         {
             "name": "java variable.name",
             "scope": "meta.definition.variable.name.java",
             "settings": {
-                "foreground": "#d9e0ee"
+                "foreground": "#cdd6f4"
             }
         },
         {
@@ -767,7 +767,7 @@
             "name": "support.constant.property-value.scss",
             "scope": "support.constant.property-value.scss,support.constant.property-value.css",
             "settings": {
-                "foreground": "#fae3b0"
+                "foreground": "#f9e2af"
             }
         },
         {
@@ -781,21 +781,21 @@
             "name": "css color standard name",
             "scope": "support.constant.color.w3c-standard-color-name.css,support.constant.color.w3c-standard-color-name.scss",
             "settings": {
-                "foreground": "#fae3b0"
+                "foreground": "#f9e2af"
             }
         },
         {
             "name": "css comma",
             "scope": "punctuation.separator.list.comma.css",
             "settings": {
-                "foreground": "#d9e0ee"
+                "foreground": "#cdd6f4"
             }
         },
         {
             "name": "css attribute-name.id",
             "scope": "support.constant.color.w3c-standard-color-name.css",
             "settings": {
-                "foreground": "#fae3b0"
+                "foreground": "#f9e2af"
             }
         },
         {
@@ -809,28 +809,28 @@
             "name": "js/ts module",
             "scope": "support.module.node,support.type.object.module,support.module.node",
             "settings": {
-                "foreground": "#f8bd96"
+                "foreground": "#fab387"
             }
         },
         {
             "name": "entity.name.type.module",
             "scope": "entity.name.type.module",
             "settings": {
-                "foreground": "#f8bd96"
+                "foreground": "#fab387"
             }
         },
         {
             "name": "js variable readwrite",
             "scope": "variable.other.readwrite,meta.object-literal.key,support.variable.property,support.variable.object.process,support.variable.object.node",
             "settings": {
-                "foreground": "#d9e0ee"
+                "foreground": "#cdd6f4"
             }
         },
         {
             "name": "js/ts json",
             "scope": "support.constant.json",
             "settings": {
-                "foreground": "#fae3b0"
+                "foreground": "#f9e2af"
             }
         },
         {
@@ -843,35 +843,35 @@
                 "keyword.operator.expression.keyof"
             ],
             "settings": {
-                "foreground": "#f28fad"
+                "foreground": "#f38ba8"
             }
         },
         {
             "name": "js/ts console",
             "scope": "support.type.object.console",
             "settings": {
-                "foreground": "#b5e8e0"
+                "foreground": "#94e2d5"
             }
         },
         {
             "name": "js/ts support.variable.property.process",
             "scope": "support.variable.property.process",
             "settings": {
-                "foreground": "#fae3b0"
+                "foreground": "#f9e2af"
             }
         },
         {
             "name": "js console function",
             "scope": "entity.name.function,support.function.console",
             "settings": {
-                "foreground": "#96cdfb"
+                "foreground": "#89b4fa"
             }
         },
         {
             "name": "operator",
             "scope": "keyword.operator.delete",
             "settings": {
-                "foreground": "#f28fad"
+                "foreground": "#f38ba8"
             }
         },
         {
@@ -885,7 +885,7 @@
             "name": "js dom variable",
             "scope": ["support.variable.dom", "support.variable.property.dom"],
             "settings": {
-                "foreground": "#b5e8e0"
+                "foreground": "#94e2d5"
             }
         },
         {
@@ -923,14 +923,14 @@
             "name": "Punctuation",
             "scope": "punctuation.separator.delimiter",
             "settings": {
-                "foreground": "#d9e0ee"
+                "foreground": "#cdd6f4"
             }
         },
         {
             "name": "Other punctuation .c",
             "scope": "punctuation.separator.c,punctuation.separator.cpp",
             "settings": {
-                "foreground": "#f28fad"
+                "foreground": "#f38ba8"
             }
         },
         {
@@ -944,7 +944,7 @@
             "name": "keyword.operator.sizeof.c",
             "scope": "keyword.operator.sizeof.c,keyword.operator.sizeof.cpp",
             "settings": {
-                "foreground": "#f28fad"
+                "foreground": "#f38ba8"
             }
         },
         {
@@ -958,14 +958,14 @@
             "name": "python block",
             "scope": "punctuation.definition.arguments.begin.python,punctuation.definition.arguments.end.python,punctuation.separator.arguments.python,punctuation.definition.list.begin.python,punctuation.definition.list.end.python",
             "settings": {
-                "foreground": "#d9e0ee"
+                "foreground": "#cdd6f4"
             }
         },
         {
             "name": "python function-call.generic",
             "scope": "meta.function-call.generic.python",
             "settings": {
-                "foreground": "#96cdfb",
+                "foreground": "#89b4fa",
                 "fontStyle": "italic"
             }
         },
@@ -973,7 +973,7 @@
             "name": "python placeholder reset to normal string",
             "scope": "constant.character.format.placeholder.other.python",
             "settings": {
-                "foreground": "#fae3b0"
+                "foreground": "#f9e2af"
             }
         },
         {
@@ -988,49 +988,49 @@
             "name": "Keywords",
             "scope": "keyword",
             "settings": {
-                "foreground": "#f28fad"
+                "foreground": "#f38ba8"
             }
         },
         {
             "name": "Namespaces",
             "scope": "entity.name.namespace",
             "settings": {
-                "foreground": "#f8bd96"
+                "foreground": "#fab387"
             }
         },
         {
             "name": "Language variables",
             "scope": "variable.language",
             "settings": {
-                "foreground": "#f8bd96"
+                "foreground": "#fab387"
             }
         },
         {
             "name": "Java Variables",
             "scope": "token.variable.parameter.java",
             "settings": {
-                "foreground": "#d9e0ee"
+                "foreground": "#cdd6f4"
             }
         },
         {
             "name": "Java Imports",
             "scope": "import.storage.java",
             "settings": {
-                "foreground": "#f8bd96"
+                "foreground": "#fab387"
             }
         },
         {
             "name": "Packages",
             "scope": "token.package.keyword",
             "settings": {
-                "foreground": "#f28fad"
+                "foreground": "#f38ba8"
             }
         },
         {
             "name": "Packages",
             "scope": "token.package",
             "settings": {
-                "foreground": "#d9e0ee"
+                "foreground": "#cdd6f4"
             }
         },
         {
@@ -1042,7 +1042,7 @@
                 "variable.function"
             ],
             "settings": {
-                "foreground": "#96cdfb",
+                "foreground": "#89b4fa",
                 "fontStyle": "italic"
             }
         },
@@ -1050,21 +1050,21 @@
             "name": "Classes",
             "scope": "entity.name.type.namespace",
             "settings": {
-                "foreground": "#f8bd96"
+                "foreground": "#fab387"
             }
         },
         {
             "name": "Classes",
             "scope": "support.class, entity.name.type.class",
             "settings": {
-                "foreground": "#f8bd96"
+                "foreground": "#fab387"
             }
         },
         {
             "name": "Class name",
             "scope": "entity.name.class.identifier.namespace.type",
             "settings": {
-                "foreground": "#f8bd96"
+                "foreground": "#fab387"
             }
         },
         {
@@ -1075,70 +1075,70 @@
                 "variable.other.class.ts"
             ],
             "settings": {
-                "foreground": "#f8bd96"
+                "foreground": "#fab387"
             }
         },
         {
             "name": "Class name php",
             "scope": "variable.other.class.php",
             "settings": {
-                "foreground": "#b5e8e0"
+                "foreground": "#94e2d5"
             }
         },
         {
             "name": "Type Name",
             "scope": "entity.name.type",
             "settings": {
-                "foreground": "#f8bd96"
+                "foreground": "#fab387"
             }
         },
         {
             "name": "Keyword Control",
             "scope": "keyword.control",
             "settings": {
-                "foreground": "#f28fad"
+                "foreground": "#f38ba8"
             }
         },
         {
             "name": "Control Elements",
             "scope": "control.elements, keyword.operator.less",
             "settings": {
-                "foreground": "#fae3b0"
+                "foreground": "#f9e2af"
             }
         },
         {
             "name": "Methods",
             "scope": "keyword.other.special-method",
             "settings": {
-                "foreground": "#96cdfb"
+                "foreground": "#89b4fa"
             }
         },
         {
             "name": "Storage",
             "scope": "storage",
             "settings": {
-                "foreground": "#f28fad"
+                "foreground": "#f38ba8"
             }
         },
         {
             "name": "Storage JS TS",
             "scope": "token.storage",
             "settings": {
-                "foreground": "#f28fad"
+                "foreground": "#f38ba8"
             }
         },
         {
             "name": "Source Js Keyword Operator Delete,source Js Keyword Operator In,source Js Keyword Operator Of,source Js Keyword Operator Instanceof,source Js Keyword Operator New,source Js Keyword Operator Typeof,source Js Keyword Operator Void",
             "scope": "keyword.operator.expression.delete,keyword.operator.expression.in,keyword.operator.expression.of,keyword.operator.expression.instanceof,keyword.operator.new,keyword.operator.expression.typeof,keyword.operator.expression.void",
             "settings": {
-                "foreground": "#f28fad"
+                "foreground": "#f38ba8"
             }
         },
         {
             "name": "Java Storage",
             "scope": "token.storage.type.java",
             "settings": {
-                "foreground": "#f8bd96"
+                "foreground": "#fab387"
             }
         },
         {
@@ -1152,42 +1152,42 @@
             "name": "Support type",
             "scope": "support.type.property-name",
             "settings": {
-                "foreground": "#d9e0ee"
+                "foreground": "#cdd6f4"
             }
         },
         {
             "name": "Support type",
             "scope": "support.constant.property-value",
             "settings": {
-                "foreground": "#d9e0ee"
+                "foreground": "#cdd6f4"
             }
         },
         {
             "name": "Support type",
             "scope": "support.constant.font-name",
             "settings": {
-                "foreground": "#fae3b0"
+                "foreground": "#f9e2af"
             }
         },
         {
             "name": "Meta tag",
             "scope": "meta.tag",
             "settings": {
-                "foreground": "#d9e0ee"
+                "foreground": "#cdd6f4"
             }
         },
         {
             "name": "Strings",
             "scope": "string",
             "settings": {
-                "foreground": "#abe9b3"
+                "foreground": "#a6e3a1"
             }
         },
         {
             "name": "Inherited Class",
             "scope": "entity.other.inherited-class",
             "settings": {
-                "foreground": "#f8bd96"
+                "foreground": "#fab387"
             }
         },
         {
@@ -1201,35 +1201,35 @@
             "name": "Integers",
             "scope": "constant.numeric",
             "settings": {
-                "foreground": "#f8bd96"
+                "foreground": "#fab387"
             }
         },
         {
             "name": "Constants",
             "scope": "constant",
             "settings": {
-                "foreground": "#fae3b0"
+                "foreground": "#f9e2af"
             }
         },
         {
             "name": "Constants",
             "scope": "punctuation.definition.constant",
             "settings": {
-                "foreground": "#fae3b0"
+                "foreground": "#f9e2af"
             }
         },
         {
             "name": "Tags",
             "scope": "entity.name.tag",
             "settings": {
-                "foreground": "#b5e8e0"
+                "foreground": "#94e2d5"
             }
         },
         {
             "name": "Attributes",
             "scope": "entity.other.attribute-name",
             "settings": {
-                "foreground": "#fae3b0"
+                "foreground": "#f9e2af"
             }
         },
         {
@@ -1237,7 +1237,7 @@
             "scope": "entity.other.attribute-name.id",
             "settings": {
                 "fontStyle": "",
-                "foreground": "#96cdfb"
+                "foreground": "#89b4fa"
             }
         },
         {
@@ -1245,119 +1245,119 @@
             "scope": "entity.other.attribute-name.class.css",
             "settings": {
                 "fontStyle": "",
-                "foreground": "#fae3b0"
+                "foreground": "#f9e2af"
             }
         },
         {
             "name": "Selector",
             "scope": "meta.selector",
             "settings": {
-                "foreground": "#f28fad"
+                "foreground": "#f38ba8"
             }
         },
         {
             "name": "Headings",
             "scope": "markup.heading",
             "settings": {
-                "foreground": "#b5e8e0"
+                "foreground": "#94e2d5"
             }
         },
         {
             "name": "Headings",
             "scope": "markup.heading punctuation.definition.heading, entity.name.section",
             "settings": {
-                "foreground": "#96cdfb"
+                "foreground": "#89b4fa"
             }
         },
         {
             "name": "Units",
             "scope": "keyword.other.unit",
             "settings": {
-                "foreground": "#b5e8e0"
+                "foreground": "#94e2d5"
             }
         },
         {
             "name": "Bold",
             "scope": "markup.bold,todo.bold",
             "settings": {
-                "foreground": "#fae3b0"
+                "foreground": "#f9e2af"
             }
         },
         {
             "name": "Bold",
             "scope": "punctuation.definition.bold",
             "settings": {
-                "foreground": "#f8bd96"
+                "foreground": "#fab387"
             }
         },
         {
             "name": "markup Italic",
             "scope": "markup.italic, punctuation.definition.italic,todo.emphasis",
             "settings": {
-                "foreground": "#f28fad"
+                "foreground": "#f38ba8"
             }
         },
         {
             "name": "emphasis md",
             "scope": "emphasis md",
             "settings": {
-                "foreground": "#f28fad"
+                "foreground": "#f38ba8"
             }
         },
         {
             "name": "[VSCODE-CUSTOM] Markdown headings",
             "scope": "entity.name.section.markdown",
             "settings": {
-                "foreground": "#b5e8e0"
+                "foreground": "#94e2d5"
             }
         },
         {
             "name": "[VSCODE-CUSTOM] Markdown heading Punctuation Definition",
             "scope": "punctuation.definition.heading.markdown",
             "settings": {
-                "foreground": "#b5e8e0"
+                "foreground": "#94e2d5"
             }
         },
         {
             "name": "punctuation.definition.list.begin.markdown",
             "scope": "punctuation.definition.list.begin.markdown",
             "settings": {
-                "foreground": "#b5e8e0"
+                "foreground": "#94e2d5"
             }
         },
         {
             "name": "[VSCODE-CUSTOM] Markdown heading setext",
             "scope": "markup.heading.setext",
             "settings": {
-                "foreground": "#d9e0ee"
+                "foreground": "#cdd6f4"
             }
         },
         {
             "name": "[VSCODE-CUSTOM] Markdown Punctuation Definition Bold",
             "scope": "punctuation.definition.bold.markdown",
             "settings": {
-                "foreground": "#fae3b0"
+                "foreground": "#f9e2af"
             }
         },
         {
             "name": "[VSCODE-CUSTOM] Markdown Inline Raw",
             "scope": "markup.inline.raw.markdown",
             "settings": {
-                "foreground": "#abe9b3"
+                "foreground": "#a6e3a1"
             }
         },
         {
             "name": "[VSCODE-CUSTOM] Markdown Inline Raw",
             "scope": "markup.inline.raw.string.markdown",
             "settings": {
-                "foreground": "#abe9b3"
+                "foreground": "#a6e3a1"
             }
         },
         {
             "name": "[VSCODE-CUSTOM] Markdown List Punctuation Definition",
             "scope": "punctuation.definition.list.markdown",
             "settings": {
-                "foreground": "#b5e8e0"
+                "foreground": "#94e2d5"
             }
         },
         {
@@ -1368,35 +1368,35 @@
                 "punctuation.definition.metadata.markdown"
             ],
             "settings": {
-                "foreground": "#b5e8e0"
+                "foreground": "#94e2d5"
             }
         },
         {
             "name": "beginning.punctuation.definition.list.markdown",
             "scope": ["beginning.punctuation.definition.list.markdown"],
             "settings": {
-                "foreground": "#b5e8e0"
+                "foreground": "#94e2d5"
             }
         },
         {
             "name": "[VSCODE-CUSTOM] Markdown Punctuation Definition Link",
             "scope": "punctuation.definition.metadata.markdown",
             "settings": {
-                "foreground": "#b5e8e0"
+                "foreground": "#94e2d5"
             }
         },
         {
             "name": "[VSCODE-CUSTOM] Markdown Underline Link/Image",
             "scope": "markup.underline.link.markdown,markup.underline.link.image.markdown",
             "settings": {
-                "foreground": "#f28fad"
+                "foreground": "#f38ba8"
             }
         },
         {
             "name": "[VSCODE-CUSTOM] Markdown Link Title/Description",
             "scope": "string.other.link.title.markdown,string.other.link.description.markdown",
             "settings": {
-                "foreground": "#96cdfb"
+                "foreground": "#89b4fa"
             }
         },
         {
@@ -1417,14 +1417,14 @@
             "name": "Embedded",
             "scope": "punctuation.section.embedded, variable.interpolation",
             "settings": {
-                "foreground": "#b5e8e0"
+                "foreground": "#94e2d5"
             }
         },
         {
             "name": "Embedded",
             "scope": "punctuation.section.embedded.begin,punctuation.section.embedded.end",
             "settings": {
-                "foreground": "#f28fad"
+                "foreground": "#f38ba8"
             }
         },
         {
@@ -1438,7 +1438,7 @@
             "name": "illegal",
             "scope": "invalid.illegal.bad-ampersand.html",
             "settings": {
-                "foreground": "#d9e0ee"
+                "foreground": "#cdd6f4"
             }
         },
         {
@@ -1466,49 +1466,49 @@
             "name": "laravel blade tag",
             "scope": "text.html.laravel-blade source.php.embedded.line.html entity.name.tag.laravel-blade",
             "settings": {
-                "foreground": "#f28fad"
+                "foreground": "#f38ba8"
             }
         },
         {
             "name": "laravel blade @",
             "scope": "text.html.laravel-blade source.php.embedded.line.html support.constant.laravel-blade",
             "settings": {
-                "foreground": "#f28fad"
+                "foreground": "#f38ba8"
             }
         },
         {
             "name": "use statement for other classes",
             "scope": "support.other.namespace.use.php,support.other.namespace.use-as.php,support.other.namespace.php,entity.other.alias.php,meta.interface.php",
             "settings": {
-                "foreground": "#f8bd96"
+                "foreground": "#fab387"
             }
         },
         {
             "name": "error suppression",
             "scope": "keyword.operator.error-control.php",
             "settings": {
-                "foreground": "#f28fad"
+                "foreground": "#f38ba8"
             }
         },
         {
             "name": "php instanceof",
             "scope": "keyword.operator.type.php",
             "settings": {
-                "foreground": "#f28fad"
+                "foreground": "#f38ba8"
             }
         },
         {
             "name": "style double quoted array index normal begin",
             "scope": "punctuation.section.array.begin.php",
             "settings": {
-                "foreground": "#d9e0ee"
+                "foreground": "#cdd6f4"
             }
         },
         {
             "name": "style double quoted array index normal end",
             "scope": "punctuation.section.array.end.php",
             "settings": {
-                "foreground": "#d9e0ee"
+                "foreground": "#cdd6f4"
             }
         },
         {
@@ -1522,35 +1522,35 @@
             "name": "php types",
             "scope": "storage.type.php,meta.other.type.phpdoc.php,keyword.other.type.php,keyword.other.array.phpdoc.php",
             "settings": {
-                "foreground": "#f8bd96"
+                "foreground": "#fab387"
             }
         },
         {
             "name": "php call-function",
             "scope": "meta.function-call.php,meta.function-call.object.php,meta.function-call.static.php",
             "settings": {
-                "foreground": "#96cdfb"
+                "foreground": "#89b4fa"
             }
         },
         {
             "name": "php function-resets",
             "scope": "punctuation.definition.parameters.begin.bracket.round.php,punctuation.definition.parameters.end.bracket.round.php,punctuation.separator.delimiter.php,punctuation.section.scope.begin.php,punctuation.section.scope.end.php,punctuation.terminator.expression.php,punctuation.definition.arguments.begin.bracket.round.php,punctuation.definition.arguments.end.bracket.round.php,punctuation.definition.storage-type.begin.bracket.round.php,punctuation.definition.storage-type.end.bracket.round.php,punctuation.definition.array.begin.bracket.round.php,punctuation.definition.array.end.bracket.round.php,punctuation.definition.begin.bracket.round.php,punctuation.definition.end.bracket.round.php,punctuation.definition.begin.bracket.curly.php,punctuation.definition.end.bracket.curly.php,punctuation.definition.section.switch-block.end.bracket.curly.php,punctuation.definition.section.switch-block.start.bracket.curly.php,punctuation.definition.section.switch-block.begin.bracket.curly.php,punctuation.definition.section.switch-block.end.bracket.curly.php",
             "settings": {
-                "foreground": "#d9e0ee"
+                "foreground": "#cdd6f4"
             }
         },
         {
             "name": "support php constants",
             "scope": "support.constant.ext.php,support.constant.std.php,support.constant.core.php,support.constant.parser-token.php",
             "settings": {
-                "foreground": "#fae3b0"
+                "foreground": "#f9e2af"
             }
         },
         {
             "name": "php goto",
             "scope": "entity.name.goto-label.php,support.other.php",
             "settings": {
-                "foreground": "#96cdfb"
+                "foreground": "#89b4fa"
             }
         },
         {
@@ -1564,7 +1564,7 @@
             "name": "php regexp operator",
             "scope": "keyword.operator.regexp.php",
             "settings": {
-                "foreground": "#f28fad"
+                "foreground": "#f38ba8"
             }
         },
         {
@@ -1578,14 +1578,14 @@
             "name": "php heredoc/nowdoc",
             "scope": "keyword.operator.heredoc.php,keyword.operator.nowdoc.php",
             "settings": {
-                "foreground": "#f28fad"
+                "foreground": "#f38ba8"
             }
         },
         {
             "name": "python function decorator @",
             "scope": "meta.function.decorator.python",
             "settings": {
-                "foreground": "#96cdfb"
+                "foreground": "#89b4fa"
             }
         },
         {
@@ -1599,21 +1599,21 @@
             "name": "parameter function js/ts",
             "scope": "function.parameter",
             "settings": {
-                "foreground": "#d9e0ee"
+                "foreground": "#cdd6f4"
             }
         },
         {
             "name": "brace function",
             "scope": "function.brace",
             "settings": {
-                "foreground": "#d9e0ee"
+                "foreground": "#cdd6f4"
             }
         },
         {
             "name": "parameter function ruby cs",
             "scope": "function.parameter.ruby, function.parameter.cs",
             "settings": {
-                "foreground": "#d9e0ee"
+                "foreground": "#cdd6f4"
             }
         },
         {
@@ -1634,61 +1634,61 @@
             "name": "rgb value",
             "scope": "inline-color-decoration rgb-value",
             "settings": {
-                "foreground": "#fae3b0"
+                "foreground": "#f9e2af"
             }
         },
         {
             "name": "rgb value less",
             "scope": "less rgb-value",
             "settings": {
-                "foreground": "#fae3b0"
+                "foreground": "#f9e2af"
             }
         },
         {
             "name": "sass selector",
             "scope": "selector.sass",
             "settings": {
-                "foreground": "#b5e8e0"
+                "foreground": "#94e2d5"
             }
         },
         {
             "name": "ts primitive/builtin types",
             "scope": "support.type.primitive.ts,support.type.builtin.ts,support.type.primitive.tsx,support.type.builtin.tsx",
             "settings": {
-                "foreground": "#f8bd96"
+                "foreground": "#fab387"
             }
         },
         {
             "name": "block scope",
             "scope": "block.scope.end,block.scope.begin",
             "settings": {
-                "foreground": "#d9e0ee"
+                "foreground": "#cdd6f4"
             }
         },
         {
             "name": "cs storage type",
             "scope": "storage.type.cs",
             "settings": {
-                "foreground": "#f8bd96"
+                "foreground": "#fab387"
             }
         },
         {
             "name": "cs local variable",
             "scope": "entity.name.variable.local.cs",
             "settings": {
-                "foreground": "#d9e0ee"
+                "foreground": "#cdd6f4"
             }
         },
         {
             "scope": "token.info-token",
             "settings": {
-                "foreground": "#96cdfb"
+                "foreground": "#89b4fa"
             }
         },
         {
             "scope": "token.warn-token",
             "settings": {
-                "foreground": "#fae3b0"
+                "foreground": "#f9e2af"
             }
         },
         {
@@ -1700,7 +1700,7 @@
         {
             "scope": "token.debug-token",
             "settings": {
-                "foreground": "#f28fad"
+                "foreground": "#f38ba8"
             }
         },
         {
@@ -1711,77 +1711,77 @@
                 "punctuation.section.embedded"
             ],
             "settings": {
-                "foreground": "#f28fad"
+                "foreground": "#f38ba8"
             }
         },
         {
             "name": "Reset JavaScript string interpolation expression",
             "scope": ["meta.template.expression"],
             "settings": {
-                "foreground": "#d9e0ee"
+                "foreground": "#cdd6f4"
             }
         },
         {
             "name": "Import module JS",
             "scope": ["keyword.operator.module"],
             "settings": {
-                "foreground": "#f28fad"
+                "foreground": "#f38ba8"
             }
         },
         {
             "name": "js Flowtype",
             "scope": ["support.type.type.flowtype"],
             "settings": {
-                "foreground": "#96cdfb"
+                "foreground": "#89b4fa"
             }
         },
         {
             "name": "js Flow",
             "scope": ["support.type.primitive"],
             "settings": {
-                "foreground": "#f8bd96"
+                "foreground": "#fab387"
             }
         },
         {
             "name": "js class prop",
             "scope": ["meta.property.object"],
             "settings": {
-                "foreground": "#b5e8e0"
+                "foreground": "#94e2d5"
             }
         },
         {
             "name": "js func parameter",
             "scope": ["variable.parameter.function.js"],
             "settings": {
-                "foreground": "#b5e8e0"
+                "foreground": "#94e2d5"
             }
         },
         {
             "name": "js template literals begin",
             "scope": ["keyword.other.template.begin"],
             "settings": {
-                "foreground": "#abe9b3"
+                "foreground": "#a6e3a1"
             }
         },
         {
             "name": "js template literals end",
             "scope": ["keyword.other.template.end"],
             "settings": {
-                "foreground": "#abe9b3"
+                "foreground": "#a6e3a1"
             }
         },
         {
             "name": "js template literals variable braces begin",
             "scope": ["keyword.other.substitution.begin"],
             "settings": {
-                "foreground": "#abe9b3"
+                "foreground": "#a6e3a1"
             }
         },
         {
             "name": "js template literals variable braces end",
             "scope": ["keyword.other.substitution.end"],
             "settings": {
-                "foreground": "#abe9b3"
+                "foreground": "#a6e3a1"
             }
         },
         {
@@ -1791,14 +1791,14 @@
                 "keyword.operator.address.go"
             ],
             "settings": {
-                "foreground": "#f28fad"
+                "foreground": "#f38ba8"
             }
         },
         {
             "name": "Go package name",
             "scope": ["entity.name.package.go"],
             "settings": {
-                "foreground": "#f8bd96"
+                "foreground": "#fab387"
             }
         },
         {
@@ -1812,21 +1812,21 @@
             "name": "elm constant",
             "scope": ["support.constant.elm"],
             "settings": {
-                "foreground": "#fae3b0"
+                "foreground": "#f9e2af"
             }
         },
         {
             "name": "template literal",
             "scope": ["punctuation.quasi.element"],
             "settings": {
-                "foreground": "#f28fad"
+                "foreground": "#f38ba8"
             }
         },
         {
             "name": "html/pug (jade) escaped characters and entities",
             "scope": ["constant.character.entity"],
             "settings": {
-                "foreground": "#b5e8e0"
+                "foreground": "#94e2d5"
             }
         },
         {
@@ -1843,14 +1843,14 @@
             "name": "Clojure globals",
             "scope": ["entity.global.clojure"],
             "settings": {
-                "foreground": "#f8bd96"
+                "foreground": "#fab387"
             }
         },
         {
             "name": "Clojure symbols",
             "scope": ["meta.symbol.clojure"],
             "settings": {
-                "foreground": "#b5e8e0"
+                "foreground": "#94e2d5"
             }
         },
         {
@@ -1867,14 +1867,14 @@
                 "variable.parameter.function.coffee"
             ],
             "settings": {
-                "foreground": "#b5e8e0"
+                "foreground": "#94e2d5"
             }
         },
         {
             "name": "Ini Default Text",
             "scope": ["source.ini"],
             "settings": {
-                "foreground": "#abe9b3"
+                "foreground": "#a6e3a1"
             }
         },
 
@@ -1882,7 +1882,7 @@
             "name": "Shell definition variables",
             "scope": ["punctuation.definition.variable.shell"],
             "settings": {
-                "foreground": "#988ba2"
+                "foreground": "#7f849c"
             }
         },
         {
@@ -1896,28 +1896,28 @@
             "name": "Shell clauses",
             "scope": ["meta.scope.case-clause-body.shell"],
             "settings": {
-                "foreground": "#d9e0ee"
+                "foreground": "#cdd6f4"
             }
         },
         {
             "name": "Shell funcs",
             "scope": ["meta.scope.group.shell"],
             "settings": {
-                "foreground": "#96cdfb"
+                "foreground": "#89b4fa"
             }
         },
         {
             "name": "Shell interpolated cmds",
             "scope": ["string.interpolated.dollar.shell"],
             "settings": {
-                "foreground": "#fae3b0"
+                "foreground": "#f9e2af"
             }
         },
         {
             "name": "Shell interpolated strings",
             "scope": ["string.quoted.single.shell"],
             "settings": {
-                "foreground": "#c9cbff"
+                "foreground": "#b4befe"
             }
         },
         {
@@ -1931,28 +1931,28 @@
             "name": "Shell group definition",
             "scope": ["punctuation.definition.group.shell"],
             "settings": {
-                "foreground": "#988ba2"
+                "foreground": "#7f849c"
             }
         },
         {
             "name": "Shell conditionals",
             "scope": ["keyword.control.shell"],
             "settings": {
-                "foreground": "#ddb6f2"
+                "foreground": "#cba6f7"
             }
         },
         {
             "name": "Shell opeartors and punct delimeters",
             "scope": ["keyword.operator.list.shell"],
             "settings": {
-                "foreground": "#b5e8e0"
+                "foreground": "#94e2d5"
             }
         },
         {
             "name": "Shell parenthesis",
             "scope": ["punctuation.definition.logical-expression.shell"],
             "settings": {
-                "foreground": "#988ba2"
+                "foreground": "#7f849c"
             }
         },
 
@@ -1960,49 +1960,49 @@
             "name": "Makefile prerequisities",
             "scope": ["meta.scope.prerequisites.makefile"],
             "settings": {
-                "foreground": "#b5e8e0"
+                "foreground": "#94e2d5"
             }
         },
         {
             "name": "Makefile text colour",
             "scope": ["source.makefile"],
             "settings": {
-                "foreground": "#f8bd96"
+                "foreground": "#fab387"
             }
         },
         {
             "name": "Groovy import names",
             "scope": ["storage.modifier.import.groovy"],
             "settings": {
-                "foreground": "#f8bd96"
+                "foreground": "#fab387"
             }
         },
         {
             "name": "Groovy Methods",
             "scope": ["meta.method.groovy"],
             "settings": {
-                "foreground": "#96cdfb"
+                "foreground": "#89b4fa"
             }
         },
         {
             "name": "Groovy Variables",
             "scope": ["meta.definition.variable.name.groovy"],
             "settings": {
-                "foreground": "#b5e8e0"
+                "foreground": "#94e2d5"
             }
         },
         {
             "name": "Groovy Inheritance",
             "scope": ["meta.definition.class.inherited.classes.groovy"],
             "settings": {
-                "foreground": "#abe9b3"
+                "foreground": "#a6e3a1"
             }
         },
         {
             "name": "HLSL Semantic",
             "scope": ["support.variable.semantic.hlsl"],
             "settings": {
-                "foreground": "#f8bd96"
+                "foreground": "#fab387"
             }
         },
         {
@@ -2016,28 +2016,28 @@
                 "support.type.object.hlsl"
             ],
             "settings": {
-                "foreground": "#f28fad"
+                "foreground": "#f38ba8"
             }
         },
         {
             "name": "SQL Variables",
             "scope": ["text.variable", "text.bracketed"],
             "settings": {
-                "foreground": "#b5e8e0"
+                "foreground": "#94e2d5"
             }
         },
         {
             "name": "types",
             "scope": ["support.type.swift", "support.type.vb.asp"],
             "settings": {
-                "foreground": "#f8bd96"
+                "foreground": "#fab387"
             }
         },
         {
             "name": "heading 1, keyword",
             "scope": ["entity.name.function.xi"],
             "settings": {
-                "foreground": "#96cdfb"
+                "foreground": "#89b4fa"
             }
         },
         {
@@ -2051,14 +2051,14 @@
             "name": "heading 3, property",
             "scope": ["constant.character.character-class.regexp.xi"],
             "settings": {
-                "foreground": "#b5e8e0"
+                "foreground": "#94e2d5"
             }
         },
         {
             "name": "heading 4, type, class, interface",
             "scope": ["constant.regexp.xi"],
             "settings": {
-                "foreground": "#f28fad"
+                "foreground": "#f38ba8"
             }
         },
         {
@@ -2072,42 +2072,42 @@
             "name": "heading 6, number",
             "scope": ["invalid.xi"],
             "settings": {
-                "foreground": "#d9e0ee"
+                "foreground": "#cdd6f4"
             }
         },
         {
             "name": "string",
             "scope": ["beginning.punctuation.definition.quote.markdown.xi"],
             "settings": {
-                "foreground": "#abe9b3"
+                "foreground": "#a6e3a1"
             }
         },
         {
             "name": "comments",
             "scope": ["beginning.punctuation.definition.list.markdown.xi"],
             "settings": {
-                "foreground": "#6e6c7e"
+                "foreground": "#6c7086"
             }
         },
         {
             "name": "link",
             "scope": ["constant.character.xi"],
             "settings": {
-                "foreground": "#96cdfb"
+                "foreground": "#89b4fa"
             }
         },
         {
             "name": "accent",
             "scope": ["accent.xi"],
             "settings": {
-                "foreground": "#96cdfb"
+                "foreground": "#89b4fa"
             }
         },
         {
             "name": "wikiword",
             "scope": ["wikiword.xi"],
             "settings": {
-                "foreground": "#fae3b0"
+                "foreground": "#f9e2af"
             }
         },
         {
@@ -2121,7 +2121,7 @@
             "name": "elements to dim",
             "scope": ["punctuation.definition.tag.xi"],
             "settings": {
-                "foreground": "#6e6c7e"
+                "foreground": "#6c7086"
             }
         },
         {
@@ -2132,14 +2132,14 @@
                 "markup.heading.setext.2.markdown"
             ],
             "settings": {
-                "foreground": "#b5e8e0"
+                "foreground": "#94e2d5"
             }
         },
         {
             "name": "meta.brace.square",
             "scope": [" meta.brace.square"],
             "settings": {
-                "foreground": "#d9e0ee"
+                "foreground": "#cdd6f4"
             }
         },
         {
@@ -2147,21 +2147,21 @@
             "scope": "comment, punctuation.definition.comment",
             "settings": {
                 "fontStyle": "italic",
-                "foreground": "#6e6c7e"
+                "foreground": "#6c7086"
             }
         },
         {
             "name": "[VSCODE-CUSTOM] Markdown Quote",
             "scope": "markup.quote.markdown",
             "settings": {
-                "foreground": "#6e6c7e"
+                "foreground": "#6c7086"
             }
         },
         {
             "name": "punctuation.definition.block.sequence.item.yaml",
             "scope": "punctuation.definition.block.sequence.item.yaml",
             "settings": {
-                "foreground": "#d9e0ee"
+                "foreground": "#cdd6f4"
             }
         },
         {
@@ -2188,7 +2188,7 @@
             "name": "python keyword import",
             "scope": "keyword.control.import.python",
             "settings": {
-                "foreground": "#b5e8e0",
+                "foreground": "#94e2d5",
                 "fontStyle": "italic"
             }
         },
@@ -2196,7 +2196,7 @@
             "name": "python keyword flow",
             "scope": "keyword.control.flow.python",
             "settings": {
-                "foreground": "#ddb6f2",
+                "foreground": "#cba6f7",
                 "fontStyle": "bold"
             }
         },
@@ -2204,7 +2204,7 @@
             "name": "python storage type",
             "scope": "storage.type.function.python",
             "settings": {
-                "foreground": "#e8a2af",
+                "foreground": "#eba0ac",
                 "fontStyle": "italic"
             }
         },
@@ -2217,252 +2217,252 @@
         }
     ],
     "colors": {
-        "foreground": "#d9e0ee",
-        "focusBorder": "#96cdfb",
-        "selection.background": "#6e6c7e",
+        "foreground": "#cdd6f4",
+        "focusBorder": "#89b4fa",
+        "selection.background": "#6c7086",
         "scrollbar.shadow": "#1e1e2e",
-        "activityBar.foreground": "#d9e0ee",
+        "activityBar.foreground": "#cdd6f4",
         "activityBar.background": "#1e1e2e",
-        "activityBar.inactiveForeground": "#d9e0ee5a",
+        "activityBar.inactiveForeground": "#cdd6f45a",
         "activityBarBadge.foreground": "#1e1e2e",
-        "activityBarBadge.background": "#96cdfb",
-        "sideBar.background": "#1a1826",
-        "sideBar.foreground": "#d9e0ee",
+        "activityBarBadge.background": "#89b4fa",
+        "sideBar.background": "#181825",
+        "sideBar.foreground": "#cdd6f4",
         "sideBarSectionHeader.background": "#00000000",
-        "sideBarSectionHeader.foreground": "#d9e0ee",
-        "sideBarTitle.foreground": "#d9e0ee",
+        "sideBarSectionHeader.foreground": "#cdd6f4",
+        "sideBarTitle.foreground": "#cdd6f4",
         "list.inactiveSelectionBackground": "#1e1e2e",
-        "list.inactiveSelectionForeground": "#d9e0ee",
+        "list.inactiveSelectionForeground": "#cdd6f4",
         "list.hoverBackground": "#1e1e2e",
-        "list.hoverForeground": "#d9e0ee",
-        "list.activeSelectionBackground": "#575268",
-        "list.activeSelectionForeground": "#d9e0ee",
-        "tree.indentGuidesStroke": "#6e6c7e",
+        "list.hoverForeground": "#cdd6f4",
+        "list.activeSelectionBackground": "#585b70",
+        "list.activeSelectionForeground": "#cdd6f4",
+        "tree.indentGuidesStroke": "#6c7086",
         "list.dropBackground": "#1e1e2e",
-        "list.highlightForeground": "#96cdfb",
-        "list.focusBackground": "#302d41",
-        "list.focusForeground": "#d9e0ee",
-        "listFilterWidget.background": "#302d41",
+        "list.highlightForeground": "#89b4fa",
+        "list.focusBackground": "#45475a",
+        "list.focusForeground": "#cdd6f4",
+        "listFilterWidget.background": "#45475a",
         "listFilterWidget.outline": "#00000000",
-        "listFilterWidget.noMatchesOutline": "#f28fad",
-        "statusBar.foreground": "#d9e0ee",
-        "statusBar.background": "#302d41",
+        "listFilterWidget.noMatchesOutline": "#f38ba8",
+        "statusBar.foreground": "#cdd6f4",
+        "statusBar.background": "#45475a",
         "statusBarItem.hoverBackground": "#ffffff1f",
-        "statusBar.debuggingBackground": "#f28fad",
-        "statusBar.debuggingForeground": "#302d41",
-        "statusBar.noFolderBackground": "#ddb6f2",
-        "statusBar.noFolderForeground": "#302d41",
-        "statusBarItem.remoteBackground": "#abe9b3",
-        "statusBarItem.remoteForeground": "#302d41",
+        "statusBar.debuggingBackground": "#f38ba8",
+        "statusBar.debuggingForeground": "#45475a",
+        "statusBar.noFolderBackground": "#cba6f7",
+        "statusBar.noFolderForeground": "#45475a",
+        "statusBarItem.remoteBackground": "#a6e3a1",
+        "statusBarItem.remoteForeground": "#45475a",
         "titleBar.activeBackground": "#1e1e2e",
-        "titleBar.activeForeground": "#d9e0ee",
+        "titleBar.activeForeground": "#cdd6f4",
         "titleBar.inactiveBackground": "#1e1e2e91",
-        "titleBar.inactiveForeground": "#d9e0ee80",
+        "titleBar.inactiveForeground": "#cdd6f480",
         "titleBar.border": "#00000000",
-        "menubar.selectionForeground": "#d9e0ee",
-        "menubar.selectionBackground": "#302d41",
-        "menu.foreground": "#d9e0ee",
-        "menu.background": "#302d41",
-        "menu.selectionForeground": "#d9e0ee",
-        "menu.selectionBackground": "#575268",
+        "menubar.selectionForeground": "#cdd6f4",
+        "menubar.selectionBackground": "#45475a",
+        "menu.foreground": "#cdd6f4",
+        "menu.background": "#45475a",
+        "menu.selectionForeground": "#cdd6f4",
+        "menu.selectionBackground": "#585b70",
         "menu.selectionBorder": "#00000000",
-        "menu.separatorBackground": "#d9e0ee",
+        "menu.separatorBackground": "#cdd6f4",
         "menu.border": "#00000085",
-        "button.background": "#575268",
-        "button.foreground": "#d9e0ee",
-        "button.hoverBackground": "#302d41",
-        "button.secondaryForeground": "#d9e0ee",
-        "button.secondaryBackground": "#302d41",
+        "button.background": "#585b70",
+        "button.foreground": "#cdd6f4",
+        "button.hoverBackground": "#45475a",
+        "button.secondaryForeground": "#cdd6f4",
+        "button.secondaryBackground": "#45475a",
         "button.secondaryHoverBackground": "#1e1e2e",
         "input.background": "#1e1e2e",
         "input.border": "#00000000",
-        "input.foreground": "#d9e0ee",
-        "inputOption.activeBackground": "#96cdfb26",
-        "inputOption.activeBorder": "#96cdfb00",
-        "inputOption.activeForeground": "#d9e0ee",
-        "input.placeholderForeground": "#d9e0ee70",
-        "textLink.foreground": "#96cdfb",
+        "input.foreground": "#cdd6f4",
+        "inputOption.activeBackground": "#89b4fa26",
+        "inputOption.activeBorder": "#89b4fa00",
+        "inputOption.activeForeground": "#cdd6f4",
+        "input.placeholderForeground": "#cdd6f470",
+        "textLink.foreground": "#89b4fa",
         "editor.background": "#1e1e2e",
-        "editor.foreground": "#d9e0ee",
-        "editorLineNumber.foreground": "#988ba2",
+        "editor.foreground": "#cdd6f4",
+        "editorLineNumber.foreground": "#7f849c",
         "editorCursor.foreground": "#f5e0dc",
         "editorCursor.background": "#1e1e2e",
-        "editor.selectionBackground": "#575268",
+        "editor.selectionBackground": "#585b70",
         "editor.inactiveSelectionBackground": "#FFFFFF20",
-        "editorWhitespace.foreground": "#c3bac618",
-        "editor.selectionHighlightBackground": "#c3bac65e",
+        "editorWhitespace.foreground": "#9399b218",
+        "editor.selectionHighlightBackground": "#9399b25e",
         "editor.selectionHighlightBorder": "#89dceb30",
-        "editor.findMatchBackground": "#575268",
-        "editor.findMatchBorder": "#96cdfb6a",
-        "editor.findMatchHighlightBackground": "#f8bd965e",
+        "editor.findMatchBackground": "#585b70",
+        "editor.findMatchBorder": "#89b4fa6a",
+        "editor.findMatchHighlightBackground": "#fab3875e",
         "editor.findMatchHighlightBorder": "#ffffff00",
-        "editor.findRangeHighlightBackground": "#57526848",
+        "editor.findRangeHighlightBackground": "#585b7048",
         "editor.findRangeHighlightBorder": "#ffffff00",
-        "editor.rangeHighlightBackground": "#96cdfb3c",
+        "editor.rangeHighlightBackground": "#89b4fa3c",
         "editor.rangeHighlightBorder": "#ffffff00",
-        "editor.hoverHighlightBackground": "#96cdfb3c",
-        "editor.wordHighlightStrongBackground": "#575268",
+        "editor.hoverHighlightBackground": "#89b4fa3c",
+        "editor.wordHighlightStrongBackground": "#585b70",
         "editor.wordHighlightBackground": "#575757b8",
         "editor.lineHighlightBackground": "#ffffff0A",
         "editor.lineHighlightBorder": "#1e1e2e",
-        "editorLineNumber.activeForeground": "#abe9b3",
-        "editorLink.activeForeground": "#96cdfb",
-        "editorIndentGuide.background": "#302d41",
-        "editorIndentGuide.activeBackground": "#575268",
-        "editorRuler.foreground": "#575268",
-        "editorBracketMatch.background": "#c3bac614",
-        "editorBracketMatch.border": "#c3bac6",
-        "editor.foldBackground": "#96cdfb42",
+        "editorLineNumber.activeForeground": "#a6e3a1",
+        "editorLink.activeForeground": "#89b4fa",
+        "editorIndentGuide.background": "#45475a",
+        "editorIndentGuide.activeBackground": "#585b70",
+        "editorRuler.foreground": "#585b70",
+        "editorBracketMatch.background": "#9399b214",
+        "editorBracketMatch.border": "#9399b2",
+        "editor.foldBackground": "#89b4fa42",
         "editorOverviewRuler.background": "#25252500",
         "editorOverviewRuler.border": "#FFFFFF0F",
-        "editorError.foreground": "#f28fad",
+        "editorError.foreground": "#f38ba8",
         "editorError.background": "#B73A3400",
         "editorError.border": "#ffffff00",
-        "editorWarning.foreground": "#fae3b0",
+        "editorWarning.foreground": "#f9e2af",
         "editorWarning.background": "#A9904000",
         "editorWarning.border": "#ffffff00",
-        "editorInfo.foreground": "#96cdfb",
+        "editorInfo.foreground": "#89b4fa",
         "editorInfo.background": "#4490BF00",
         "editorInfo.border": "#4490BF00",
         "editorGutter.background": "#1e1e2e",
         "editorGutter.modifiedBackground": "#89dceb",
-        "editorGutter.addedBackground": "#abe9b3",
-        "editorGutter.deletedBackground": "#f28fad",
-        "editorGutter.foldingControlForeground": "#c3bac6",
-        "editorCodeLens.foreground": "#988ba2",
-        "editorGroup.border": "#575268",
+        "editorGutter.addedBackground": "#a6e3a1",
+        "editorGutter.deletedBackground": "#f38ba8",
+        "editorGutter.foldingControlForeground": "#9399b2",
+        "editorCodeLens.foreground": "#7f849c",
+        "editorGroup.border": "#585b70",
         // test
-        "diffEditor.insertedTextBackground": "#abe9b318",
-        "diffEditor.removedTextBackground": "#f28fad1c",
-        "diffEditor.border": "#575268",
+        "diffEditor.insertedTextBackground": "#a6e3a118",
+        "diffEditor.removedTextBackground": "#f38ba81c",
+        "diffEditor.border": "#585b70",
         "panel.background": "#1e1e2e",
-        "panel.border": "#575268",
-        "panelTitle.activeBorder": "#d9e0ee",
-        "panelTitle.activeForeground": "#d9e0ee",
-        "panelTitle.inactiveForeground": "#d9e0eead",
-        "badge.background": "#302d41",
-        "badge.foreground": "#d9e0ee",
-        "terminal.foreground": "#d9e0ee",
-        "terminal.selectionBackground": "#57526834",
+        "panel.border": "#585b70",
+        "panelTitle.activeBorder": "#cdd6f4",
+        "panelTitle.activeForeground": "#cdd6f4",
+        "panelTitle.inactiveForeground": "#cdd6f4ad",
+        "badge.background": "#45475a",
+        "badge.foreground": "#cdd6f4",
+        "terminal.foreground": "#cdd6f4",
+        "terminal.selectionBackground": "#585b7034",
         "terminalCursor.background": "#1e1e2e",
         "terminalCursor.foreground": "#f5e0dc",
-        "terminal.border": "#575268",
-        "terminal.ansiBlack": "#6e6c7e",
-        "terminal.ansiBlue": "#96cdfb",
-        "terminal.ansiBrightBlack": "#988ba2",
-        "terminal.ansiBrightBlue": "#96cdfb",
+        "terminal.border": "#585b70",
+        "terminal.ansiBlack": "#6c7086",
+        "terminal.ansiBlue": "#89b4fa",
+        "terminal.ansiBrightBlack": "#7f849c",
+        "terminal.ansiBrightBlue": "#89b4fa",
         "terminal.ansiBrightCyan": "#89dceb",
-        "terminal.ansiBrightGreen": "#abe9b3",
+        "terminal.ansiBrightGreen": "#a6e3a1",
         "terminal.ansiBrightMagenta": "#f5c2e7",
-        "terminal.ansiBrightRed": "#f28fad",
-        "terminal.ansiBrightWhite": "#d9e0ee",
-        "terminal.ansiBrightYellow": "#fae3b0",
+        "terminal.ansiBrightRed": "#f38ba8",
+        "terminal.ansiBrightWhite": "#cdd6f4",
+        "terminal.ansiBrightYellow": "#f9e2af",
         "terminal.ansiCyan": "#89dceb",
-        "terminal.ansiGreen": "#abe9b3",
+        "terminal.ansiGreen": "#a6e3a1",
         "terminal.ansiMagenta": "#f5c2e7",
-        "terminal.ansiRed": "#f28fad",
-        "terminal.ansiWhite": "#c3bac6",
-        "terminal.ansiYellow": "#fae3b0",
+        "terminal.ansiRed": "#f38ba8",
+        "terminal.ansiWhite": "#9399b2",
+        "terminal.ansiYellow": "#f9e2af",
         "breadcrumb.background": "#1e1e2e",
-        "breadcrumb.foreground": "#d9e0eecd",
-        "breadcrumb.focusForeground": "#d9e0ee",
+        "breadcrumb.foreground": "#cdd6f4cd",
+        "breadcrumb.focusForeground": "#cdd6f4",
         "editorGroupHeader.tabsBackground": "#1e1e2e",
-        "tab.activeForeground": "#d9e0ee",
-        "tab.border": "#302d41",
+        "tab.activeForeground": "#cdd6f4",
+        "tab.border": "#45475a",
         "tab.activeBackground": "#1e1e2e",
         "tab.activeBorder": "#00000000",
         "tab.activeBorderTop": "#00000000",
-        "tab.inactiveBackground": "#302d41",
-        "tab.inactiveForeground": "#d9e0ee64",
-        "scrollbarSlider.background": "#5752687e",
-        "scrollbarSlider.hoverBackground": "#6e6c7e",
+        "tab.inactiveBackground": "#45475a",
+        "tab.inactiveForeground": "#cdd6f464",
+        "scrollbarSlider.background": "#585b707e",
+        "scrollbarSlider.hoverBackground": "#6c7086",
         "scrollbarSlider.activeBackground": "#bfbfbf66",
-        "progressBar.background": "#96cdfb",
+        "progressBar.background": "#89b4fa",
         "widget.shadow": "#00000080",
-        "editorWidget.foreground": "#d9e0ee",
+        "editorWidget.foreground": "#cdd6f4",
         "editorWidget.background": "#1e1e2e",
-        "editorWidget.resizeBorder": "#575268",
-        "pickerGroup.border": "#96cdfb",
-        "pickerGroup.foreground": "#96cdfb",
-        "debugToolBar.background": "#302d41",
-        "debugToolBar.border": "#575268",
-        "notifications.foreground": "#d9e0ee",
-        "notifications.background": "#302d41",
-        "notificationToast.border": "#575268",
-        "notificationsErrorIcon.foreground": "#f28fad",
-        "notificationsWarningIcon.foreground": "#fae3b0",
-        "notificationsInfoIcon.foreground": "#96cdfb",
-        "notificationCenter.border": "#575268",
-        "notificationCenterHeader.foreground": "#d9e0ee",
+        "editorWidget.resizeBorder": "#585b70",
+        "pickerGroup.border": "#89b4fa",
+        "pickerGroup.foreground": "#89b4fa",
+        "debugToolBar.background": "#45475a",
+        "debugToolBar.border": "#585b70",
+        "notifications.foreground": "#cdd6f4",
+        "notifications.background": "#45475a",
+        "notificationToast.border": "#585b70",
+        "notificationsErrorIcon.foreground": "#f38ba8",
+        "notificationsWarningIcon.foreground": "#f9e2af",
+        "notificationsInfoIcon.foreground": "#89b4fa",
+        "notificationCenter.border": "#585b70",
+        "notificationCenterHeader.foreground": "#cdd6f4",
         "notificationCenterHeader.background": "#1e1e2e",
-        "notifications.border": "#302d41",
-        "gitDecoration.addedResourceForeground": "#abe9b3",
-        "gitDecoration.conflictingResourceForeground": "#ddb6f2",
-        "gitDecoration.deletedResourceForeground": "#f28fad",
-        "gitDecoration.ignoredResourceForeground": "#6e6c7e",
-        "gitDecoration.modifiedResourceForeground": "#fae3b0",
-        "gitDecoration.stageDeletedResourceForeground": "#f28fad",
-        "gitDecoration.stageModifiedResourceForeground": "#fae3b0",
-        "gitDecoration.submoduleResourceForeground": "#96cdfb",
-        "gitDecoration.untrackedResourceForeground": "#abe9b3",
-        "editorMarkerNavigation.background": "#302d41",
-        "editorMarkerNavigationError.background": "#f28fad",
-        "editorMarkerNavigationWarning.background": "#fae3b0",
-        "editorMarkerNavigationInfo.background": "#96cdfb",
+        "notifications.border": "#45475a",
+        "gitDecoration.addedResourceForeground": "#a6e3a1",
+        "gitDecoration.conflictingResourceForeground": "#cba6f7",
+        "gitDecoration.deletedResourceForeground": "#f38ba8",
+        "gitDecoration.ignoredResourceForeground": "#6c7086",
+        "gitDecoration.modifiedResourceForeground": "#f9e2af",
+        "gitDecoration.stageDeletedResourceForeground": "#f38ba8",
+        "gitDecoration.stageModifiedResourceForeground": "#f9e2af",
+        "gitDecoration.submoduleResourceForeground": "#89b4fa",
+        "gitDecoration.untrackedResourceForeground": "#a6e3a1",
+        "editorMarkerNavigation.background": "#45475a",
+        "editorMarkerNavigationError.background": "#f38ba8",
+        "editorMarkerNavigationWarning.background": "#f9e2af",
+        "editorMarkerNavigationInfo.background": "#89b4fa",
         "merge.currentHeaderBackground": "#158472",
         "merge.currentContentBackground": "#27403B",
         "merge.incomingHeaderBackground": "#395F8F",
         "merge.incomingContentBackground": "#243A5E",
-        "merge.commonHeaderBackground": "#575268",
-        "merge.commonContentBackground": "#302d41",
-        "editorSuggestWidget.background": "#302d41",
-        "editorSuggestWidget.border": "#575268",
-        "editorSuggestWidget.foreground": "#d9e0ee",
-        "editorSuggestWidget.highlightForeground": "#96cdfb",
-        "editorSuggestWidget.selectedBackground": "#575268",
-        "editorHoverWidget.foreground": "#d9e0ee",
-        "editorHoverWidget.background": "#302d41",
-        "editorHoverWidget.border": "#575268",
-        "peekView.border": "#96cdfb",
-        "peekViewEditor.background": "#302d41",
-        "peekViewEditorGutter.background": "#302d41",
-        "peekViewEditor.matchHighlightBackground": "#f8bd9640",
-        "peekViewEditor.matchHighlightBorder": "#f8bd96",
-        "peekViewResult.background": "#302d41",
-        "peekViewResult.fileForeground": "#d9e0ee",
-        "peekViewResult.lineForeground": "#d9e0ee",
-        "peekViewResult.matchHighlightBackground": "#f8bd9640",
-        "peekViewResult.selectionBackground": "#575268",
-        "peekViewResult.selectionForeground": "#d9e0ee",
+        "merge.commonHeaderBackground": "#585b70",
+        "merge.commonContentBackground": "#45475a",
+        "editorSuggestWidget.background": "#45475a",
+        "editorSuggestWidget.border": "#585b70",
+        "editorSuggestWidget.foreground": "#cdd6f4",
+        "editorSuggestWidget.highlightForeground": "#89b4fa",
+        "editorSuggestWidget.selectedBackground": "#585b70",
+        "editorHoverWidget.foreground": "#cdd6f4",
+        "editorHoverWidget.background": "#45475a",
+        "editorHoverWidget.border": "#585b70",
+        "peekView.border": "#89b4fa",
+        "peekViewEditor.background": "#45475a",
+        "peekViewEditorGutter.background": "#45475a",
+        "peekViewEditor.matchHighlightBackground": "#fab38740",
+        "peekViewEditor.matchHighlightBorder": "#fab387",
+        "peekViewResult.background": "#45475a",
+        "peekViewResult.fileForeground": "#cdd6f4",
+        "peekViewResult.lineForeground": "#cdd6f4",
+        "peekViewResult.matchHighlightBackground": "#fab38740",
+        "peekViewResult.selectionBackground": "#585b70",
+        "peekViewResult.selectionForeground": "#cdd6f4",
         "peekViewTitle.background": "#1e1e2e",
         "peekViewTitleDescription.foreground": "#ccccccb3",
-        "peekViewTitleLabel.foreground": "#d9e0ee",
-        "icon.foreground": "#d9e0ee",
+        "peekViewTitleLabel.foreground": "#cdd6f4",
+        "icon.foreground": "#cdd6f4",
         "checkbox.background": "#1e1e2e",
-        "checkbox.foreground": "#d9e0ee",
+        "checkbox.foreground": "#cdd6f4",
         "checkbox.border": "#00000000",
         "dropdown.background": "#1e1e2e",
-        "dropdown.foreground": "#d9e0ee",
+        "dropdown.foreground": "#cdd6f4",
         "dropdown.border": "#00000000",
-        "minimapGutter.addedBackground": "#abe9b3",
+        "minimapGutter.addedBackground": "#a6e3a1",
         "minimapGutter.modifiedBackground": "#89dceb",
-        "minimapGutter.deletedBackground": "#f28fad",
-        "minimap.findMatchHighlight": "#575268",
-        "minimap.selectionHighlight": "#575268",
-        "minimap.errorHighlight": "#f28fad",
-        "minimap.warningHighlight": "#fae3b0",
+        "minimapGutter.deletedBackground": "#f38ba8",
+        "minimap.findMatchHighlight": "#585b70",
+        "minimap.selectionHighlight": "#585b70",
+        "minimap.errorHighlight": "#f38ba8",
+        "minimap.warningHighlight": "#f9e2af",
         "minimap.background": "#1e1e2e",
-        "sideBar.dropBackground": "#1a1826",
+        "sideBar.dropBackground": "#181825",
         "editorGroup.emptyBackground": "#1e1e2e",
-        "panelSection.border": "#575268",
+        "panelSection.border": "#585b70",
         "statusBarItem.activeBackground": "#FFFFFF25",
-        "settings.headerForeground": "#d9e0ee",
+        "settings.headerForeground": "#cdd6f4",
         "settings.focusedRowBackground": "#ffffff07",
         "walkThrough.embeddedEditorBackground": "#00000050",
-        "breadcrumb.activeSelectionForeground": "#d9e0ee",
-        "editorGutter.commentRangeForeground": "#c3bac6",
-        "debugExceptionWidget.background": "#302d41",
-        "debugExceptionWidget.border": "#575268",
+        "breadcrumb.activeSelectionForeground": "#cdd6f4",
+        "editorGutter.commentRangeForeground": "#9399b2",
+        "debugExceptionWidget.background": "#45475a",
+        "debugExceptionWidget.border": "#585b70",
         "activitusbar.inactiveColour": "#000000",
         "activitusbar.activeColour": "#000000"
     }


### PR DESCRIPTION
This commit features a "minimal" port to v0.2.0. Minimal here meaning the fewest amount of changes necessary to convert the old color theme to Mocha and then generating the other themes based on that.

I tried to keep this as unopinionated as possible, assuming that the previous iterations were good enough and that they just needed to be made compatible. This means that the new Subtext colors as well as Crust remain unused.  If a custom color not part of the old color scheme was used (such is the case with `semanticTokenColors` among a few others,) then that color was left unchanged.