### PR TITLE
fix: c++ variables

### DIFF
--- a/themes/Catppuccin-frappe-color-theme.json
+++ b/themes/Catppuccin-frappe-color-theme.json
@@ -439,6 +439,13 @@
             }
         },
         {
+            "name": "C++ Variables",
+            "scope": "variable.other.local.cpp",
+            "settings": {
+                "foreground": "#c6d0f5",
+            }
+        },
+        {
             "name": "C++ Operators",
             "scope": [
                 "punctuation.separator.scope-resolution.cpp",

--- a/themes/Catppuccin-latte-color-theme.json
+++ b/themes/Catppuccin-latte-color-theme.json
@@ -439,6 +439,13 @@
             }
         },
         {
+            "name": "C++ Variables",
+            "scope": "variable.other.local.cpp",
+            "settings": {
+                "foreground": "#4c4f69",
+            }
+        },
+        {
             "name": "C++ Operators",
             "scope": [
                 "punctuation.separator.scope-resolution.cpp",

--- a/themes/Catppuccin-macchiato-color-theme.json
+++ b/themes/Catppuccin-macchiato-color-theme.json
@@ -439,6 +439,13 @@
             }
         },
         {
+            "name": "C++ Variables",
+            "scope": "variable.other.local.cpp",
+            "settings": {
+                "foreground": "#cad3f5",
+            }
+        },
+        {
             "name": "C++ Operators",
             "scope": [
                 "punctuation.separator.scope-resolution.cpp",
@@ -2342,7 +2349,7 @@
         "editorGutter.foldingControlForeground": "#939ab7",
         "editorCodeLens.foreground": "#8087a2",
         "editorGroup.border": "#5b6078",
-        // diff editor colors 
+        // diff editor colors
         "diffEditor.insertedTextBackground": "#a6da9518",
         "diffEditor.removedTextBackground": "#ed87961c",
         "diffEditor.border": "#5b6078",

--- a/themes/Catppuccin-mocha-color-theme.json
+++ b/themes/Catppuccin-mocha-color-theme.json
@@ -439,6 +439,13 @@
             }
         },
         {
+            "name": "C++ Variables",
+            "scope": "variable.other.local.cpp",
+            "settings": {
+                "foreground": "#cdd6f4",
+            }
+        },
+        {
             "name": "C++ Operators",
             "scope": [
                 "punctuation.separator.scope-resolution.cpp",
@@ -2342,7 +2349,7 @@
         "editorGutter.foldingControlForeground": "#9399b2",
         "editorCodeLens.foreground": "#7f849c",
         "editorGroup.border": "#585b70",
-        // diff editor colors 
+        // diff editor colors
         "diffEditor.insertedTextBackground": "#a6e3a118",
         "diffEditor.removedTextBackground": "#f38ba81c",
         "diffEditor.border": "#585b70",


### PR DESCRIPTION
C++ variables were all `Flamingo` which made it hard to differentiate between properties/parameters and local variables, and made files very orange, so I changed them to `Text`.