### PR TITLE
feat: support extension in vscode web

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,16 @@
       }
     ]
   },
+  "extensionKind": [
+    "ui",
+    "workspace"
+  ],
+  "capabilities": {
+    "untrustedWorkspaces": {
+      "supported": true
+    },
+    "virtualWorkspaces": true
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/catppuccin/vscode.git"


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/20012970/192110962-2c50d5ea-b52a-4c22-b39c-a29b2f8bcde8.png)

With this setting in `package.json`, catppuccin is available in vscode web.
Please release new version if this PR is merged. Thanks.