### PR TITLE
Change editor.wordHighlightStrongBackground

### DIFF
--- a/src/theme/uiColors.ts
+++ b/src/theme/uiColors.ts
@@ -92,7 +92,7 @@ export const getUiColors = (context: ThemeContext) => {
     "editor.rangeHighlightBackground": opacity(palette.sky, 0.25),
     "editor.rangeHighlightBorder": transparent,
     "editor.hoverHighlightBackground": opacity(palette.sky, 0.25),
-    "editor.wordHighlightStrongBackground": palette.surface2,
+    "editor.wordHighlightStrongBackground": opacity(palette.surface2, 0.5),
     "editor.wordHighlightBackground": opacity(palette.surface2, 0.7),
     "editor.lineHighlightBackground": opacity(palette.text, 0.07),
     "editor.lineHighlightBorder": palette.base,

--- a/themes/frappe.json
+++ b/themes/frappe.json
@@ -2451,7 +2451,7 @@
     "editor.rangeHighlightBackground": "#99d1db3f",
     "editor.rangeHighlightBorder": "#00000000",
     "editor.hoverHighlightBackground": "#99d1db3f",
-    "editor.wordHighlightStrongBackground": "#626880",
+    "editor.wordHighlightStrongBackground": "#6268807f",
     "editor.wordHighlightBackground": "#626880b2",
     "editor.lineHighlightBackground": "#c6d0f511",
     "editor.lineHighlightBorder": "#303446",

--- a/themes/latte.json
+++ b/themes/latte.json
@@ -2451,7 +2451,7 @@
     "editor.rangeHighlightBackground": "#04a5e53f",
     "editor.rangeHighlightBorder": "#00000000",
     "editor.hoverHighlightBackground": "#04a5e53f",
-    "editor.wordHighlightStrongBackground": "#acb0be",
+    "editor.wordHighlightStrongBackground": "#acb0be7f",
     "editor.wordHighlightBackground": "#acb0beb2",
     "editor.lineHighlightBackground": "#4c4f6911",
     "editor.lineHighlightBorder": "#eff1f5",

--- a/themes/macchiato.json
+++ b/themes/macchiato.json
@@ -2451,7 +2451,7 @@
     "editor.rangeHighlightBackground": "#91d7e33f",
     "editor.rangeHighlightBorder": "#00000000",
     "editor.hoverHighlightBackground": "#91d7e33f",
-    "editor.wordHighlightStrongBackground": "#5b6078",
+    "editor.wordHighlightStrongBackground": "#5b60787f",
     "editor.wordHighlightBackground": "#5b6078b2",
     "editor.lineHighlightBackground": "#cad3f511",
     "editor.lineHighlightBorder": "#24273a",

--- a/themes/mocha.json
+++ b/themes/mocha.json
@@ -2451,7 +2451,7 @@
     "editor.rangeHighlightBackground": "#89dceb3f",
     "editor.rangeHighlightBorder": "#00000000",
     "editor.hoverHighlightBackground": "#89dceb3f",
-    "editor.wordHighlightStrongBackground": "#585b70",
+    "editor.wordHighlightStrongBackground": "#585b707f",
     "editor.wordHighlightBackground": "#585b70b2",
     "editor.lineHighlightBackground": "#cdd6f411",
     "editor.lineHighlightBorder": "#1e1e2e",


### PR DESCRIPTION
Having both editor.wordHighlightStrongBackground and editor.selectionBackground set to the same value makes it impossible to see selections in the active token. Applying 50% opacity to the token highlight restores functionality; I haven't checked to see if this issue exists in the other palettes.