### PR TITLE
feat: improved whitespaces highlighting

### DIFF
--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -2509,7 +2509,7 @@ export const compileTheme = (
             "editorCursor.background": palette.base,
             "editor.selectionBackground": palette.surface2,
             "editor.inactiveSelectionBackground": transparent,
-            "editorWhitespace.foreground": opacity(palette.overlay2, 0.1),
+            "editorWhitespace.foreground": opacity(palette.overlay2, 0.4),
             "editor.selectionHighlightBackground": opacity(
                 palette.overlay2,
                 0.4

--- a/themes/Catppuccin-frappe-color-theme.json
+++ b/themes/Catppuccin-frappe-color-theme.json
@@ -2445,7 +2445,7 @@
         "editorCursor.background": "#303446",
         "editor.selectionBackground": "#626880",
         "editor.inactiveSelectionBackground": "#00000000",
-        "editorWhitespace.foreground": "#949cbb19",
+        "editorWhitespace.foreground": "#949cbb66",
         "editor.selectionHighlightBackground": "#949cbb66",
         "editor.selectionHighlightBorder": "#99d1db33",
         "editor.findMatchBackground": "#626880",

--- a/themes/Catppuccin-latte-color-theme.json
+++ b/themes/Catppuccin-latte-color-theme.json
@@ -2445,7 +2445,7 @@
         "editorCursor.background": "#eff1f5",
         "editor.selectionBackground": "#acb0be",
         "editor.inactiveSelectionBackground": "#00000000",
-        "editorWhitespace.foreground": "#7c7f9319",
+        "editorWhitespace.foreground": "#7c7f9366",
         "editor.selectionHighlightBackground": "#7c7f9366",
         "editor.selectionHighlightBorder": "#04a5e533",
         "editor.findMatchBackground": "#acb0be",

--- a/themes/Catppuccin-macchiato-color-theme.json
+++ b/themes/Catppuccin-macchiato-color-theme.json
@@ -2445,7 +2445,7 @@
         "editorCursor.background": "#24273a",
         "editor.selectionBackground": "#5b6078",
         "editor.inactiveSelectionBackground": "#00000000",
-        "editorWhitespace.foreground": "#939ab719",
+        "editorWhitespace.foreground": "#939ab766",
         "editor.selectionHighlightBackground": "#939ab766",
         "editor.selectionHighlightBorder": "#91d7e333",
         "editor.findMatchBackground": "#5b6078",

--- a/themes/Catppuccin-mocha-color-theme.json
+++ b/themes/Catppuccin-mocha-color-theme.json
@@ -2445,7 +2445,7 @@
         "editorCursor.background": "#1e1e2e",
         "editor.selectionBackground": "#585b70",
         "editor.inactiveSelectionBackground": "#00000000",
-        "editorWhitespace.foreground": "#9399b219",
+        "editorWhitespace.foreground": "#9399b266",
         "editor.selectionHighlightBackground": "#9399b266",
         "editor.selectionHighlightBorder": "#89dceb33",
         "editor.findMatchBackground": "#585b70",


### PR DESCRIPTION
Making whitespaces more distinguishable. Closing #47 issue.

**Before / After:**
Mocha
<img width="281" alt="image" src="https://user-images.githubusercontent.com/33329898/197354377-e20f4e90-4fd5-43c9-8787-a1f213024684.png"><img width="281" alt="image" src="https://user-images.githubusercontent.com/33329898/197354383-ac2b016a-7e19-4d6d-b3db-e31525d51238.png">

Macchiato
<img width="281" alt="image" src="https://user-images.githubusercontent.com/33329898/197354356-df606644-a0ab-4d42-b0b0-799353c85e9d.png"><img width="281" alt="image" src="https://user-images.githubusercontent.com/33329898/197354348-6edc6e9d-f5bf-490d-872e-c0d73aeda3dc.png">

Frappe
<img width="281" alt="image" src="https://user-images.githubusercontent.com/33329898/197354269-5a982e56-df0c-43f8-85bd-0f2bd6176fdb.png"><img width="281" alt="image" src="https://user-images.githubusercontent.com/33329898/197354297-1b45c70f-7501-433f-96e4-27c436ef2123.png">

Latte
<img width="281" alt="image" src="https://user-images.githubusercontent.com/33329898/197354411-0965fa28-d727-4ad3-8ff3-1adbe7335ed6.png"><img width="281" alt="image" src="https://user-images.githubusercontent.com/33329898/197354475-dd00eca5-3c46-499d-8f1e-f3817720e390.png">
