### PR TITLE
fix: trigger re-compile after updating the extension

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,14 +1,18 @@
-assets/
-schemas/
 .github/
 .husky/
+.vscode/
 .vscode-test-web/
+
+assets/
+schemas/
+themes/.flag
 
 *.vsix
 **/*.ts
-dist/hooks
+build.js
 tsconfig.json
 
+.editorconfig
 .eslintcache
 .eslintignore
 .eslintrc.js

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,18 +1,22 @@
-import { workspace, window, ConfigurationChangeEvent } from "vscode";
+import { workspace, ConfigurationChangeEvent } from "vscode";
 import { getThemePaths } from "./helpers";
-import utils from "./utils";
+import utils, { UpdateTrigger } from "./utils";
 
 export const activate = () => {
+  const config = utils.getConfiguration();
+  const paths = getThemePaths();
+
+  // regenerate the theme files when the config changes
   workspace.onDidChangeConfiguration((event: ConfigurationChangeEvent) => {
     if (event.affectsConfiguration("catppuccin")) {
-      const config = utils.getConfiguration();
-      const paths = getThemePaths();
-      utils.updateThemes(config, paths);
-      window.showInformationMessage(
-        "Catppuccin Configuration changed, re-generating the JSON theme."
-      );
+      utils.updateThemes(config, paths, UpdateTrigger.CONFIG_CHANGE);
     }
   });
+
+  // regenerate on a fresh install if non-default config is set
+  if (utils.isFreshInstall() && !utils.isDefaultConfig()) {
+    utils.updateThemes(config, paths, UpdateTrigger.FRESH_INSTALL);
+  }
 };
 
 export const deactivate = () => {};

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -9,14 +9,16 @@ import { getTokenColors } from "./tokenColors";
 import { getUiColors } from "./uiColors";
 import { capitalize } from "./utils";
 
+export const defaultOptions: ThemeOptions = {
+  accent: "mauve",
+  italicComments: true,
+  italicKeywords: true,
+  colorOverrides: {},
+};
+
 export const compileTheme = (
   flavour: CatppuccinFlavour = "mocha",
-  options: ThemeOptions = {
-    accent: "mauve",
-    italicComments: true,
-    italicKeywords: true,
-    colorOverrides: null,
-  }
+  options: ThemeOptions = defaultOptions
 ) => {
   const ctpPalette = Object.entries(variants[flavour])
     .map(([k, v]) => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,7 +1,7 @@
 import { variants } from "@catppuccin/palette";
 import * as fs from "fs";
-import { compileTheme } from "./theme";
-import { workspace, window, commands } from "vscode";
+import { compileTheme, defaultOptions } from "./theme";
+import { commands, workspace, window } from "vscode";
 import type {
   CatppuccinAccent,
   CatppuccinFlavour,
@@ -9,47 +9,73 @@ import type {
   ThemeOptions,
   ThemePaths,
 } from "./types";
+import { join } from "path";
+
+// the reason why an update has been triggered, and a reload is needed
+export enum UpdateTrigger {
+  CONFIG_CHANGE = "Configuration changed",
+  FRESH_INSTALL = "Update detected",
+}
 
 class Utils {
-  private promptToReload() {
-    const action = "Reload";
-    window
-      .showInformationMessage("Reload required.", action)
-      .then((selectedAction) => {
-        if (selectedAction === action) {
-          commands.executeCommand("workbench.action.reloadWindow");
-        }
-      });
-  }
-  private async writeFile(path: string, data: string | NodeJS.ArrayBufferView) {
-    return new Promise((resolve, reject) => {
-      fs.writeFile(path, JSON.stringify(data, null, 2), (err) =>
-        err ? reject(err) : resolve("Success")
-      );
+  private promptToReload(trigger: UpdateTrigger) {
+    const msg = `Catppuccin: ${trigger} - Reload required.`;
+    const action = "Reload window";
+    window.showInformationMessage(msg, action).then((selectedAction) => {
+      if (selectedAction === action) {
+        commands.executeCommand("workbench.action.reloadWindow");
+      }
     });
+  }
+  private writeThemeFile(path: string, data: any) {
+    return fs.writeFile(path, JSON.stringify(data, null, 2), (err) => {
+      if (err) {
+        window.showErrorMessage(err.message);
+      }
+    });
+  }
+  isFreshInstall(): boolean {
+    console.log("Checking if catppuccin is installed for the first time.");
+    const flagPath = join(__dirname, "..", "themes", ".flag");
+    if (fs.existsSync(flagPath)) {
+      console.log("Catppuccin is installed for the first time!");
+      return false;
+    } else {
+      console.log("Catppuccin has been installed before.");
+      fs.writeFileSync(flagPath, "");
+      return true;
+    }
+  }
+  isDefaultConfig(): boolean {
+    console.log("Checking if catppuccin is using default config.");
+    const state = this.getConfiguration() === defaultOptions;
+    console.log(`Catppuccin is using ${state ? "default" : "custom"} config.`);
+    return state;
   }
   getConfiguration = (): ThemeOptions => {
-    const workspaceConfiguration = workspace.getConfiguration("catppuccin");
+    const conf = workspace.getConfiguration("catppuccin");
     return {
-      accent: workspaceConfiguration.get<CatppuccinAccent>("accentColor"),
-      italicKeywords: workspaceConfiguration.get<boolean>("italicKeywords"),
-      italicComments: workspaceConfiguration.get<boolean>("italicComments"),
-      colorOverrides:
-        workspaceConfiguration.get<ColorOverrides>("colorOverrides"),
+      accent: conf.get<CatppuccinAccent>("accentColor"),
+      italicKeywords: conf.get<boolean>("italicKeywords"),
+      italicComments: conf.get<boolean>("italicComments"),
+      colorOverrides: conf.get<ColorOverrides>("colorOverrides"),
     };
   };
-  saveThemeJSON = (path: string, data: any): void => {
-    this.writeFile(path, data);
-  };
-  updateThemes = (options: ThemeOptions, paths: ThemePaths) => {
+  updateThemes = async (
+    options: ThemeOptions,
+    paths: ThemePaths,
+    trigger: UpdateTrigger
+  ) => {
     const flavours = Object.keys(variants) as CatppuccinFlavour[];
-    // TODO: use fsPromises instead of maps, then prompt to reloadA
-    //       wait for Promises.All, then prompt to reload
-    flavours.map((flavour) => {
+
+    const promises = flavours.map(async (flavour): Promise<void> => {
       const theme = compileTheme(flavour, options);
-      this.saveThemeJSON(paths[flavour], theme);
+      return this.writeThemeFile(paths[flavour], theme);
     });
-    this.promptToReload();
+
+    Promise.all(promises).then(() => {
+      this.promptToReload(trigger);
+    });
   };
 }
 


### PR DESCRIPTION
Fixes an issue I overlooked in #38. When updating from the marketplace, you had to change a setting, to trigger a recompile.

Now the theme auto-detects **first installations for each version**, and only recompiles if required.

I also improved the prompt so that the user knows why a reload is required: 
![config change prompt](https://user-images.githubusercontent.com/79978224/198682576-c0216185-042f-4d18-88ef-59c9cb1231d3.png)
![new update installed prompt](https://user-images.githubusercontent.com/79978224/198682628-cda5184c-ae6b-415c-acde-56c92a1ef81a.png)
After pressing reload in the 2nd screenshot, the theme restores itself to my tweaks in the first screenshot:
`#000000` as `base`, `mantle`, `crust` and `#ff69b4` as `pink`.