### PR TITLE
feat(ui): named color customizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,17 +57,25 @@ open the file you just downloaded.
 
 Open your settings, and look for `Extensions > Catppuccin`. Available options are documented here.
 
+### Custom accent colour
+
+`catppuccin.accentColor`
+
+You can choose any colour as your "accent" colour. `mauve` is our default, but you can add more personality by using your favourite!
+
 ### Disable italics & bold fonts
 
 You can toggle whether to use
 
-- italics for keywords
-- italics for comments
-- bold for keywords
+- italics for keywords: `catppuccin.italicKeywords`
+- italics for comments: `catppuccin.italicComments`
+- bold for keywords: `catppuccin.boldKeywords`
 
 ### Override palette colours
 
-Colors can be overwritten using `catppuccin.colorOverrides` in the JSON user settings, like so:
+`catppuccin.colorOverrides`
+
+Colors can be overwritten in the JSON user settings, like so:
 
 ```json5
     // ...your other settings...
@@ -87,6 +95,8 @@ Colors can be overwritten using `catppuccin.colorOverrides` in the JSON user set
 
 ### Use palette colours on workbench elements (UI)
 
+`catppuccin.customUIColors`
+
 If you want to customize where certain palette colours appear, you can change it like so:
 
 ```json5
@@ -96,9 +106,10 @@ If you want to customize where certain palette colours appear, you can change it
             "breadcrumb.background": "overlay0",
             "breadcrumb.foreground": "text",
         },
-        // but for mocha, use "crust" on "pink"
+        // but for mocha, use "crust" on your currently selected accent.
         "mocha": {
-            "breadcrumb.background": "pink",
+            // "accent" selects your current accent colour.
+            "breadcrumb.background": "accent",
             "breadcrumb.foreground": "crust",
             // you can use opacity, by specifing it after a space
             // "rosewater 0.5" would mean 50% opacity, here it's 20%

--- a/README.md
+++ b/README.md
@@ -50,30 +50,66 @@ Download the VSIX from
 Open the Command Palette, and select "Extensions: Install from VSIX...", then
 open the file you just downloaded.
 
-> **Note**
+> **Note**\
+> It is recommended to change `window.titleBarStyle` to `custom` in your JSON user settings.
 
-From the settings, change `window.titleBarStyle` to `custom` for the context
-menus to be properly rendered according to the theme.
+## Customization
 
-## 🙋 FAQ
+Open your settings, and look for `Extensions > Catppuccin`. Available options are documented here.
 
-- <strong>Q</strong>: <strong><em>"How can I disable italics?"</em></strong>\
-  A: Open your settings, and look for `Extensions > Catppuccin`. There you can toggle comments for both Keywords & Comments. You'll have to reload your editor once to see changes.
+### Disable italics & bold fonts
 
-- <strong>Q</strong>: <strong><em>"How can I override palette colours?"</strong></em>\
-  A: Open your Command Palette (<kbd>Cmd+Shift+P</kbd> or <kbd>Ctrl+Shift+P</kbd>), and select "Open User Settings (JSON)". Once there, make your changes like this, and reload:
+You can toggle whether to use
 
-```json
+- italics for keywords
+- italics for comments
+- bold for keywords
+
+### Override palette colours
+
+Colors can be overwritten using `catppuccin.colorOverrides` in the JSON user settings, like so:
+
+```json5
     // ...your other settings...
     "catppuccin.colorOverrides": {
-        // OLEDppuccin
+        // make text red red all flavours
+        "all": {
+            "text": "#ff0000"
+        },
+        // make Mocha "OLEDppuccin" - use black editor background
         "mocha": {
             "base": "#000000",
-            "mantle": "#000000",
-            "crust": "#000000",
+            "mantle": "#010101",
+            "crust": "#020202",
         }
     }
 ```
+
+### Use palette colours on workbench elements (UI)
+
+If you want to customize where certain palette colours appear, you can change it like so:
+
+```json5
+    "catppuccin.customUIColors": {
+        // make the breadcrumb "text" on "overlay0" for all flavours
+        "all": {
+            "breadcrumb.background": "overlay0",
+            "breadcrumb.foreground": "text",
+        },
+        // but for mocha, use "crust" on "pink"
+        "mocha": {
+            "breadcrumb.background": "pink",
+            "breadcrumb.foreground": "crust",
+            // you can use opacity, by specifing it after a space
+            // "rosewater 0.5" would mean 50% opacity, here it's 20%
+            "minimap.background": "rosewater 0.2"
+        }
+    },
+```
+
+You can find all the available keys [here](https://code.visualstudio.com/api/references/theme-color).
+
+> **Note**: This respects your [color overrides](#override-palette-colours).
 
 ## Development
 

--- a/package.json
+++ b/package.json
@@ -72,6 +72,11 @@
             "description": "Custom color overrides",
             "$ref": "https://raw.githubusercontent.com/catppuccin/vscode/main/schemas/colorOverrides.schema.json"
           },
+          "catppuccin.customUIColors": {
+            "type": "object",
+            "default": {},
+            "description": "Custom UI colors"
+          },
           "catppuccin.accentColor": {
             "type": "string",
             "default": "mauve",

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -15,6 +15,7 @@ export const defaultOptions: ThemeOptions = {
   italicComments: true,
   italicKeywords: true,
   colorOverrides: {},
+  customUIColors: {},
 };
 
 export const compileTheme = (
@@ -25,6 +26,7 @@ export const compileTheme = (
     .map(([k, v]) => {
       return {
         [k as unknown as string]: v.hex,
+        name: flavour,
       };
     })
     .reduce((acc, curr) => ({ ...acc, ...curr }), {});

--- a/src/theme/uiColors.ts
+++ b/src/theme/uiColors.ts
@@ -8,6 +8,30 @@ export const getUiColors = (context: ThemeContext) => {
 
   const dropBackground = opacity(palette.surface2, 0.6);
 
+  const customizations = {
+    ...options.customUIColors.all,
+    ...options.customUIColors[palette.name],
+  };
+
+  let customUIcol = {};
+
+  Object.entries(customizations).map(([k, v]) => {
+    //check if the entry is a "color opacity" mapping
+    const entry = v.split(" ");
+    let result: string;
+    if (entry.length !== 1) {
+      console.log(Number(entry[1]));
+      result = opacity(palette[entry[0]], Number(entry[1]));
+    } else {
+      result = palette[entry[0]];
+    }
+
+    customUIcol = {
+      ...customUIcol,
+      [k]: result,
+    };
+  });
+
   // find the definitions here:
   // https://code.visualstudio.com/api/references/theme-color
   return {
@@ -449,5 +473,6 @@ export const getUiColors = (context: ThemeContext) => {
     "charts.orange": palette.peach,
     "charts.green": palette.green,
     "charts.purple": palette.mauve,
+    ...customUIcol,
   };
 };

--- a/src/theme/uiColors.ts
+++ b/src/theme/uiColors.ts
@@ -8,29 +8,30 @@ export const getUiColors = (context: ThemeContext) => {
 
   const dropBackground = opacity(palette.surface2, 0.6);
 
-  const customizations = {
-    ...options.customUIColors.all,
-    ...options.customUIColors[palette.name],
+  // support for custom named colors
+  const customNamedColors = {
+    ...Object.entries({
+      // collect the options, overwrite the "all" config with the current palette config
+      ...options.customUIColors.all,
+      ...options.customUIColors[palette.name],
+    })
+      .map(([k, v]) => {
+        //check if the entry is a "color opacity" mapping
+        const entry = v.split(" ");
+        if (entry.length !== 1) {
+          // call the opacity function
+          v = opacity(palette[entry[0]], Number(entry[1]));
+        } else {
+          // resolve to the palette color
+          v = palette[v];
+        }
+
+        return {
+          [k]: v,
+        };
+      })
+      .reduce((prev, cur) => ({ ...prev, ...cur }), {}),
   };
-
-  let customUIcol = {};
-
-  Object.entries(customizations).map(([k, v]) => {
-    //check if the entry is a "color opacity" mapping
-    const entry = v.split(" ");
-    let result: string;
-    if (entry.length !== 1) {
-      console.log(Number(entry[1]));
-      result = opacity(palette[entry[0]], Number(entry[1]));
-    } else {
-      result = palette[entry[0]];
-    }
-
-    customUIcol = {
-      ...customUIcol,
-      [k]: result,
-    };
-  });
 
   // find the definitions here:
   // https://code.visualstudio.com/api/references/theme-color
@@ -473,6 +474,6 @@ export const getUiColors = (context: ThemeContext) => {
     "charts.orange": palette.peach,
     "charts.green": palette.green,
     "charts.purple": palette.mauve,
-    ...customUIcol,
+    ...customNamedColors,
   };
 };

--- a/src/theme/uiColors.ts
+++ b/src/theme/uiColors.ts
@@ -16,6 +16,13 @@ export const getUiColors = (context: ThemeContext) => {
       ...options.customUIColors[palette.name],
     })
       .map(([k, v]) => {
+        // deal with accents
+        if (v === "accent") {
+          return {
+            [k]: accent,
+          };
+        }
+
         //check if the entry is a "color opacity" mapping
         const entry = v.split(" ");
         if (entry.length !== 1) {

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -16,6 +16,7 @@ export type CatppuccinAccent =
   | "lavender";
 
 export interface CatppuccinPalette {
+  name: CatppuccinFlavour;
   rosewater: string;
   flamingo: string;
   pink: string;
@@ -52,12 +53,21 @@ export type ColorOverrides = {
   mocha?: Partial<CatppuccinPalette>;
 };
 
+export type CustomUIColors = {
+  all?: Record<"all", string>;
+  latte?: Record<"latte", string>;
+  frappe?: Record<"frappe", string>;
+  macchiato?: Record<"macchiato", string>;
+  mocha?: Record<"mocha", string>;
+};
+
 export type ThemeOptions = {
   accent: CatppuccinAccent;
   italicComments: boolean;
   italicKeywords: boolean;
   boldKeywords: boolean;
   colorOverrides: ColorOverrides;
+  customUIColors: CustomUIColors;
 };
 
 export type ThemePaths = {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,10 +2,11 @@ import { variants } from "@catppuccin/palette";
 import * as fs from "fs";
 import { compileTheme, defaultOptions } from "./theme";
 import { commands, workspace, window } from "vscode";
-import type {
+import {
   CatppuccinAccent,
   CatppuccinFlavour,
   ColorOverrides,
+  CustomUIColors,
   ThemeOptions,
   ThemePaths,
 } from "./types";
@@ -60,6 +61,7 @@ class Utils {
       italicKeywords: conf.get<boolean>("italicKeywords"),
       italicComments: conf.get<boolean>("italicComments"),
       colorOverrides: conf.get<ColorOverrides>("colorOverrides"),
+      customUIColors: conf.get<CustomUIColors>("customUIColors"),
     };
   };
   updateThemes = async (


### PR DESCRIPTION
@watatomo brought this up in Discord:

![image](https://user-images.githubusercontent.com/79978224/198947885-4c1865ec-99e2-40a3-8e84-c3e1fac1dff3.png)

This adds `catppuccin.customUIColors` in the JSON preferences:
![screenshot](https://cdn.discordapp.com/attachments/1020275848940626002/1036526131895074876/unknown.png)

You can either use `rosewater` to use the current Palettes `rosewater` color, or `rosewater 0.2` for `rosewater` with 20% opacity.

Please download [this artifact](https://github.com/catppuccin/vscode/suites/9041405713/artifacts/417696993) from [the CI](https://github.com/catppuccin/vscode/actions/runs/3359163539) and give it a go.