### PR TITLE
add an option for a subtle border on some UI elements

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,6 +129,11 @@
               "A monochromatic, grey appearance for matching bracket pairs.",
               "Uses the same bracket pair colors as our neovim port."
             ]
+          },
+          "catppuccin.extraBordersEnabled": {
+            "type": "boolean",
+            "default": false,
+            "description": "Controls whether borders should be enabled on some additional UI elements."
           }
         }
       }

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -17,6 +17,7 @@ export const defaultOptions: ThemeOptions = {
   colorOverrides: {},
   workbenchMode: "default",
   bracketMode: "rainbow",
+  extraBordersEnabled: false,
   customUIColors: {},
 };
 

--- a/src/theme/tokenColors.ts
+++ b/src/theme/tokenColors.ts
@@ -73,7 +73,7 @@ export const getTokenColors = (context: ThemeContext) => {
       },
     },
     {
-      name: "All punctuation delimeters",
+      name: "All punctuation delimiters",
       scope: "punctuation.semi",
       settings: {
         foreground: palette.teal,
@@ -329,7 +329,7 @@ export const getTokenColors = (context: ThemeContext) => {
       },
     },
     {
-      name: "Rust punctuation delimeters",
+      name: "Rust punctuation delimiters",
       scope: "punctuation.semi.rust",
       settings: {
         foreground: palette.teal,
@@ -447,7 +447,7 @@ export const getTokenColors = (context: ThemeContext) => {
     },
 
     {
-      name: "C++ Puct Delimeters",
+      name: "C++ Punct Delimiters",
       scope: "punctuation.terminator.statement.cpp",
       settings: {
         foreground: palette.teal,
@@ -2077,7 +2077,7 @@ export const getTokenColors = (context: ThemeContext) => {
       },
     },
     {
-      name: "Shell opeartors and punct delimeters",
+      name: "Shell operators and punct delimiters",
       scope: ["keyword.operator.list.shell"],
       settings: {
         foreground: palette.teal,

--- a/src/theme/uiColors.ts
+++ b/src/theme/uiColors.ts
@@ -86,6 +86,7 @@ export const getUiColors = (context: ThemeContext) => {
 
   const accent = palette[options.accent];
   const dropBackground = opacity(palette.surface2, 0.6);
+  const border = options.extraBordersEnabled ? opacity(palette.overlay1, 0.15) : transparent;
 
   // support for custom named colors
   const customNamedColors = {
@@ -158,7 +159,7 @@ export const getUiColors = (context: ThemeContext) => {
     "activityBar.foreground": accent,
     "activityBar.dropBar": dropBackground,
     "activityBar.inactiveForeground": palette.overlay0,
-    "activityBar.border": transparent,
+    "activityBar.border": border,
     "activityBarBadge.background": accent,
     "activityBarBadge.foreground": palette.crust,
     "activityBar.activeBorder": transparent,
@@ -184,7 +185,7 @@ export const getUiColors = (context: ThemeContext) => {
     "button.secondaryBackground": palette.surface2,
     "button.secondaryHoverBackground": shade(palette.surface2, 0.2),
     "checkbox.background": palette.surface1,
-    "checkbox.border": transparent,
+    "checkbox.border": border,
     "checkbox.foreground": accent,
 
     // dropdown controls
@@ -372,7 +373,7 @@ export const getUiColors = (context: ThemeContext) => {
     "tree.indentGuidesStroke": palette.overlay0,
 
     "menu.background": palette.base,
-    "menu.border": opacity(palette.base, 0.5),
+    "menu.border": options.extraBordersEnabled ? palette.surface2 : opacity(palette.base, 0.5),
     "menu.foreground": palette.text,
     "menu.selectionBackground": palette.surface2,
     "menu.selectionBorder": transparent,
@@ -455,6 +456,7 @@ export const getUiColors = (context: ThemeContext) => {
     "sideBar.background": palette.mantle,
     "sideBar.dropBackground": dropBackground,
     "sideBar.foreground": palette.text,
+    "sideBar.border": border,
     "sideBarSectionHeader.background": palette.mantle,
     "sideBarSectionHeader.foreground": palette.text,
     "sideBarTitle.foreground": accent,
@@ -463,6 +465,7 @@ export const getUiColors = (context: ThemeContext) => {
     // Status Bar
     "statusBar.background": palette.crust,
     "statusBar.foreground": palette.text,
+    "statusBar.border": border,
     // having no folder open shouldn't change the bar
     "statusBar.noFolderBackground": palette.crust,
     "statusBar.noFolderForeground": palette.text,
@@ -528,7 +531,7 @@ export const getUiColors = (context: ThemeContext) => {
     "titleBar.activeForeground": palette.text,
     "titleBar.inactiveBackground": palette.crust,
     "titleBar.inactiveForeground": opacity(palette.text, 0.5),
-    "titleBar.border": transparent,
+    "titleBar.border": border,
 
     // welcome page
     "welcomePage.tileBackground": palette.mantle,

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -75,6 +75,7 @@ export type ThemeOptions = {
   colorOverrides: ColorOverrides;
   workbenchMode: CatppuccinWorkbenchMode;
   bracketMode: CatppuccinBracketMode;
+  extraBordersEnabled: boolean;
   customUIColors: CustomUIColors;
 };
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -65,6 +65,7 @@ class Utils {
       colorOverrides: conf.get<ColorOverrides>("colorOverrides"),
       workbenchMode: conf.get<CatppuccinWorkbenchMode>("workbenchMode"),
       bracketMode: conf.get<CatppuccinBracketMode>("bracketMode"),
+      extraBordersEnabled: conf.get<boolean>("extraBordersEnabled"),
       customUIColors: conf.get<CustomUIColors>("customUIColors"),
     };
   };


### PR DESCRIPTION
i had a go at this to see what it would look like.

<details>
  <summary>latte</summary>

![latte](https://user-images.githubusercontent.com/289746/229244233-b5f72a4b-a27a-40e5-921a-5d6795585489.png)

</details>
<details>
  <summary>frappé</summary>

![frappe](https://user-images.githubusercontent.com/289746/229244337-64ba82b8-00fe-4547-8070-16a446c24837.png)

</details>
<details>
  <summary>macchiato</summary>

![macchiato](https://user-images.githubusercontent.com/289746/229244366-ce134b83-7a95-47de-aa21-1e500637641e.png)

</details>
<details>
  <summary>mocha</summary>

![mocha](https://user-images.githubusercontent.com/289746/229244373-8c715d63-0fd2-457d-b4f4-a39af5ed2073.png)

</details>

let me know your thoughts!

closes #92