### PR TITLE
fix: highlight border to be transparent

### DIFF
--- a/src/theme/uiColors.ts
+++ b/src/theme/uiColors.ts
@@ -268,7 +268,7 @@ export const getUiColors = (context: ThemeContext) => {
     "editor.hoverHighlightBackground": opacity(palette.sky, 0.25),
     "editor.inactiveSelectionBackground": transparent,
     "editor.lineHighlightBackground": opacity(palette.text, 0.07),
-    "editor.lineHighlightBorder": palette.base,
+    "editor.lineHighlightBorder": transparent,
     "editor.rangeHighlightBackground": opacity(palette.sky, 0.25),
     "editor.rangeHighlightBorder": transparent,
     "editor.selectionBackground": palette.surface2,


### PR DESCRIPTION
Closes #104 

## Description
Currently the highlight border is the same as editor background (`palette.base`) which overrides the highlight background, makes it looks like the highlight doesn't cover the first character. This PR changes the border to transparent, keep the minimal look of the theme while fixing above problem.

## Screenshot
![image](https://github.com/catppuccin/vscode/assets/2419328/1d5f661a-3497-4b1d-8906-5790c0a9a355)
*Before fix*

![image](https://github.com/catppuccin/vscode/assets/2419328/ecaced84-7634-4d33-ad3e-6d5d2d2e1ece)
*After fix*