### PR TITLE
fix(ui): Give PHP variable definitions correct color

### DIFF
--- a/src/theme/tokenColors.ts
+++ b/src/theme/tokenColors.ts
@@ -6,7 +6,11 @@ export const getTokenColors = (context: ThemeContext) => {
   return [
     {
       name: "All variable",
-      scope: ["variable.language", "variable.other", "punctuation.definition.variable.php"],
+      scope: [
+        "variable.language",
+        "variable.other",
+        "punctuation.definition.variable.php",
+      ],
       settings: {
         foreground: palette.flamingo,
       },

--- a/src/theme/tokenColors.ts
+++ b/src/theme/tokenColors.ts
@@ -6,7 +6,7 @@ export const getTokenColors = (context: ThemeContext) => {
   return [
     {
       name: "All variable",
-      scope: ["variable.language", "variable.other"],
+      scope: ["variable.language", "variable.other", "punctuation.definition.variable.php"],
       settings: {
         foreground: palette.flamingo,
       },


### PR DESCRIPTION
## Before:
![NVIDIA_Share_fXgVhk2fNd](https://github.com/catppuccin/vscode/assets/42468660/892fadd4-4a62-4de5-9fab-eca6915c4a04)

## After:
![NVIDIA_Share_HZ2EgKPquM](https://github.com/catppuccin/vscode/assets/42468660/de63bad9-a076-4b8a-b735-f210cbb6833f)

Should be self explanatory. Dollar symbol is not assigned a color as it is right now. Pretty simple fix, I'm not sure if the `all variable` object is the correct place to put it, but as we're talking about variable definitions I think it makes sense semantically.