### PR TITLE
fix(compiler): compile when icons aren't installed

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -34,23 +34,27 @@ export const activate = async (ctx: ExtensionContext) => {
 
 const handler = (event: ConfigurationChangeEvent, paths: ThemePaths) => {
   const id = "catppuccin.catppuccin-vsc-icons";
-  const iconsInstalled = extensions.getExtension(id).isActive;
+  const iconsActive = extensions.getExtension(id)?.isActive;
   const iconsAffected = event.affectsConfiguration("workbench.colorTheme");
 
-  if (iconsInstalled && iconsAffected) {
+  if (iconsActive && iconsAffected) {
     const theme = workspace
       .getConfiguration("workbench")
       .get<string>("colorTheme");
-    const ctp_themes = {
-      "Catppuccin Latte": "catppuccin-latte",
-      "Catppuccin Frappé": "catppuccin-frappe",
-      "Catppuccin Macchiato": "catppuccin-macchiato",
-      "Catppuccin Mocha": "catppuccin-mocha",
-    };
-    if (Object.keys(ctp_themes).includes(theme)) {
+    if (theme) {
+      const ctp_themes = {
+        "Catppuccin Latte": "catppuccin-latte",
+        "Catppuccin Frappé": "catppuccin-frappe",
+        "Catppuccin Macchiato": "catppuccin-macchiato",
+        "Catppuccin Mocha": "catppuccin-mocha",
+      };
       workspace
         .getConfiguration("workbench")
-        .update("iconTheme", ctp_themes[theme], true);
+        .update(
+          "iconTheme",
+          ctp_themes[theme as keyof typeof ctp_themes],
+          true,
+        );
     }
   }
 

--- a/src/theme/uiColors.ts
+++ b/src/theme/uiColors.ts
@@ -1,5 +1,6 @@
 import type {
   CatppuccinBracketMode,
+  CatppuccinPalette,
   CatppuccinWorkbenchMode,
   ThemeContext,
   WorkbenchColors,
@@ -156,10 +157,13 @@ export const getUiColors = (
         const entry = v.split(" ");
         if (entry.length !== 1) {
           // call the opacity function
-          v = opacity(palette[entry[0]], Number(entry[1]));
+          v = opacity(
+            palette[entry[0] as keyof CatppuccinPalette],
+            Number(entry[1]),
+          );
         } else {
           // resolve to the palette color
-          v = palette[v];
+          v = palette[v as keyof CatppuccinPalette];
         }
 
         return {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "rootDir": "./src",
     "outDir": "./dist",
     "sourceMap": false,
-    "strict": false,
+    "strict": true,
     "lib": ["es6"]
   },
   "include": ["src", "."],


### PR DESCRIPTION
Closes #159.

Pretty stupid error that got overlooked because I forgot that I hadn't set tsconfig to strict yet.