### PR TITLE
feat(syntax): Diff highlighting

### DIFF
--- a/src/theme/tokens/diff.ts
+++ b/src/theme/tokens/diff.ts
@@ -1,0 +1,43 @@
+import type { TextmateColors, ThemeContext } from "../../types";
+
+const tokens = (context: ThemeContext): TextmateColors => {
+  const { palette } = context;
+
+  return [
+    {
+      name: "Markup Diff",
+      scope: "markup.changed.diff",
+      settings: {
+        foreground: palette.peach,
+        fontStyle: "",
+      },
+    },
+    {
+      name: "Diff",
+      scope:
+        "meta.diff.header.from-file,meta.diff.header.to-file,punctuation.definition.from-file.diff,punctuation.definition.to-file.diff",
+      settings: {
+        foreground: palette.blue,
+        fontStyle: "",
+      },
+    },
+    {
+      name: "Diff Inserted",
+      scope: "markup.inserted.diff",
+      settings: {
+        foreground: palette.green,
+        fontStyle: "",
+      },
+    },
+    {
+      name: "Diff Deleted",
+      scope: "markup.deleted.diff",
+      settings: {
+        foreground: palette.red,
+        fontStyle: "",
+      },
+    },
+  ];
+};
+
+export default tokens;

--- a/src/theme/tokens/diff.ts
+++ b/src/theme/tokens/diff.ts
@@ -18,7 +18,7 @@ const tokens = (context: ThemeContext): TextmateColors => {
         "meta.diff.header.from-file",
         "meta.diff.header.to-file",
         "punctuation.definition.from-file.diff",
-        "punctuation.definition.to-file.diff"
+        "punctuation.definition.to-file.diff",
       ],
       settings: {
         foreground: palette.blue,

--- a/src/theme/tokens/diff.ts
+++ b/src/theme/tokens/diff.ts
@@ -14,8 +14,12 @@ const tokens = (context: ThemeContext): TextmateColors => {
     },
     {
       name: "Diff",
-      scope:
-        "meta.diff.header.from-file,meta.diff.header.to-file,punctuation.definition.from-file.diff,punctuation.definition.to-file.diff",
+      scope: [
+        "meta.diff.header.from-file",
+        "meta.diff.header.to-file",
+        "punctuation.definition.from-file.diff",
+        "punctuation.definition.to-file.diff"
+      ],
       settings: {
         foreground: palette.blue,
         fontStyle: "",

--- a/src/theme/tokens/index.ts
+++ b/src/theme/tokens/index.ts
@@ -3,6 +3,7 @@ import type { ThemeContext } from "../../types";
 import cpp from "./cpp";
 import css from "./css";
 import data from "./data";
+import diff from "./diff";
 import dotenv from "./dotenv";
 import golang from "./golang";
 import graphql from "./graphql";
@@ -292,6 +293,7 @@ export default (context: ThemeContext) => {
       cpp,
       css,
       data,
+      diff,
       dotenv,
       golang,
       graphql,


### PR DESCRIPTION
This PR adds syntax highlighting support for `.diff` files.

| Before | After |
|--------|--------|
| ![diff syntax highlighting before](https://github.com/catppuccin/vscode/assets/43011723/9bdacc64-f817-47b0-b291-847c92035dff) | ![diff syntax highlighting after](https://github.com/catppuccin/vscode/assets/43011723/0082651b-0358-444d-bbb7-7fa3358b56a2)|