### PR TITLE
fix(syntax): C# interpolated strings highlighting

### DIFF
--- a/src/theme/tokens/cs.ts
+++ b/src/theme/tokens/cs.ts
@@ -1,0 +1,18 @@
+import type { TextmateColors, ThemeContext } from "../../types";
+
+const tokens = (context: ThemeContext): TextmateColors => {
+  const { palette } = context;
+
+  return [
+    {
+      name: "C# Interpolated Strings",
+      scope: "meta.interpolation.cs",
+      settings: {
+        foreground: palette.text,
+        fontStyle: "",
+      },
+    },
+  ];
+};
+
+export default tokens;

--- a/src/theme/tokens/index.ts
+++ b/src/theme/tokens/index.ts
@@ -1,6 +1,7 @@
 import type { ThemeContext } from "../../types";
 
 import cpp from "./cpp";
+import cs from "./cs";
 import css from "./css";
 import data from "./data";
 import diff from "./diff";
@@ -291,6 +292,7 @@ export default (context: ThemeContext) => {
     // per-language tokens
     ...[
       cpp,
+      cs,
       css,
       data,
       diff,


### PR DESCRIPTION
| Before | After |
|--------|--------|
| ![before](https://github.com/catppuccin/vscode/assets/43011723/23e4cade-2dcd-463a-8034-ffb82fc492a6) | ![after](https://github.com/catppuccin/vscode/assets/43011723/3dd6f4a8-7af1-4fa5-b9f2-10e97dbc1962) | 


- Closes #178 
