### PR TITLE
fix: use `focusBorder` variable for keyboard navigation highlights

### DIFF
--- a/src/theme/uiColors.ts
+++ b/src/theme/uiColors.ts
@@ -177,7 +177,7 @@ export const getUiColors = (
   // https://code.visualstudio.com/api/references/theme-color
   return {
     // Base colors
-    focusBorder: transparent,
+    focusBorder: accent,
     foreground: palette.text,
     disabledForeground: palette.subtext0,
     "widget.shadow": opacity(palette.mantle, 0.5),


### PR DESCRIPTION
Closes #181