### PR TITLE
fix(nix): colors for paths, numbers, contants

### DIFF
--- a/src/theme/semanticTokens.ts
+++ b/src/theme/semanticTokens.ts
@@ -6,6 +6,8 @@ export const getSemanticTokens = (context: ThemeContext): SemanticTokens => {
   return {
     enumMember: { foreground: palette.teal },
     selfKeyword: { foreground: palette.red },
+    boolean: { foreground: palette.peach },
+    number: { foreground: palette.peach },
     "variable.defaultLibrary": { foreground: palette.maroon },
 
     // Python types
@@ -39,6 +41,9 @@ export const getSemanticTokens = (context: ThemeContext): SemanticTokens => {
     // Rust attributes
     "builtinAttribute.attribute.library:rust": { foreground: palette.blue },
     "generic.attribute:rust": { foreground: palette.text },
+
+    // Nix
+    "constant.builtin.readonly:nix": { foreground: palette.mauve },
 
     // Typst
     heading: { foreground: palette.red },

--- a/src/theme/tokens/nix.ts
+++ b/src/theme/tokens/nix.ts
@@ -30,6 +30,14 @@ const tokens = (context: ThemeContext): TextmateColors => {
         fontStyle: "",
       },
     },
+    {
+      name: "Nix paths",
+      scope: "string.unquoted.path.nix",
+      settings: {
+        foreground: palette.text,
+        fontStyle: "",
+      },
+    },
   ];
 };
 


### PR DESCRIPTION
Turns out Nix language servers do semantic highlighting

BEGIN_COMMIT_OVERRIDE
fix(syntax): nix paths, numbers, constants
END_COMMIT_OVERRIDE