### PR TITLE
fix(syntax): nix path colors

### DIFF
--- a/src/theme/tokens/nix.ts
+++ b/src/theme/tokens/nix.ts
@@ -34,7 +34,7 @@ const tokens = (context: ThemeContext): TextmateColors => {
       name: "Nix paths",
       scope: "string.unquoted.path.nix",
       settings: {
-        foreground: palette.text,
+        foreground: palette.pink,
         fontStyle: "",
       },
     },


### PR DESCRIPTION
on a second thought, paths should probably stand out more

BEGIN_COMMIT_OVERRIDE
END_COMMIT_OVERRIDE