### PR TITLE
fix(syntax): CSS operators, preprocessor parent selectors

### DIFF
--- a/src/theme/tokens/css.ts
+++ b/src/theme/tokens/css.ts
@@ -6,9 +6,19 @@ const tokens = (context: ThemeContext): TextmateColors => {
   return [
     {
       name: "Classes, reflecting the className color in JSX",
-      scope: "source.css entity.other.attribute-name.class",
+      scope: [
+        "source.css entity.other.attribute-name.class.css",
+        "entity.other.attribute-name.parent-selector.css punctuation.definition.entity.css",
+      ],
       settings: {
         foreground: palette.yellow,
+      },
+    },
+    {
+      name: "Operators",
+      scope: "punctuation.separator.operator.css",
+      settings: {
+        foreground: palette.teal,
       },
     },
     {


### PR DESCRIPTION
This is literally just a fix to force a new release since GitHub actions crashed, when the last release was supposed to run.