### PR TITLE
build(nix): optimize build speed

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -46,7 +46,7 @@
 
   extension = pkgs.stdenvNoCC.mkDerivation {
     inherit name version pname src;
-    buildInputs = [pkgs.nodejs pkgs.vsce pkgs.yarn];
+    buildInputs = [pkgs.nodejs pkgs.vsce];
 
     # check in the ./themes/.flag so it doesn't prompt for initial rebuilds
     patchPhase = ''
@@ -63,7 +63,7 @@
       cp -r ${builder}/* dist/
       touch ./themes/.flag
       node dist/hooks/generateThemes.js
-      vsce package --yarn
+      vsce package --no-dependencies
       runHook postBuild
     '';
 

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -1,13 +1,4 @@
-{pkgs ? import <nixpkgs> {}}: let
-  nodejs = pkgs.nodejs_18;
-in
-  pkgs.mkShell {
-    buildInputs = with pkgs; [
-      alejandra
-      nil
-
-      nodejs
-      corepack
-      (yarn.override {inherit nodejs;})
-    ];
-  }
+{pkgs ? import <nixpkgs> {}}:
+pkgs.mkShell {
+  buildInputs = with pkgs; [alejandra nil nodejs_18 corepack];
+}


### PR DESCRIPTION
Turns out `vsce` was the slow step, not the build.