### PR TITLE
fix(nix): accent color wasn't applying correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ This means that you will have to either:
   programs.vscode.extensions = [
     # all the theme options will be available as overrides, these are defaults:
     (pkgs.catppuccin-vsc.override {
-      accentColor = "mauve";
+      accent = "mauve";
       boldKeywords = true;
       italicComments = true;
       italicKeywords = true;

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,6 +1,7 @@
 {
   pkgs ? import <nixpkgs> {},
-  accentColor ? "mauve",
+  accentColor ? null,
+  accent ? "mauve",
   boldKeywords ? true,
   italicComments ? true,
   italicKeywords ? true,
@@ -76,7 +77,8 @@
     '';
   };
 in
-  (lib.checkListOfEnum "${pname}: accent" validAccents [accentColor])
+  (lib.throwIfNot (accentColor == null) "${pname}: deprecated option 'accentColor' is no longer supported, please use 'accent' instead.")
+  (lib.checkListOfEnum "${pname}: accent" validAccents [accent])
   (lib.checkListOfEnum "${pname}: workbenchMode" validWorkbenchModes [workbenchMode])
   (lib.checkListOfEnum "${pname}: bracketMode" validBracketModes [bracketMode])
   pkgs.vscode-utils.buildVscodeMarketplaceExtension {

--- a/src/hooks/generateThemes.ts
+++ b/src/hooks/generateThemes.ts
@@ -15,13 +15,14 @@ const flavors = Object.keys(variants) as CatppuccinFlavor[];
 
 // options can also be passed as a JSON string as an environment variable
 const optEnvVar = process.env.CATPPUCCIN_OPTIONS;
-const options = optEnvVar ? JSON.parse(optEnvVar) : {};
+const optEnv = optEnvVar ? JSON.parse(optEnvVar) : {};
 
 const main = async () => {
   await mkdir(join(repoRoot, "themes"), { recursive: true });
 
   flavors.map((flavor) => {
-    const theme = compileTheme(flavor, { ...defaultOptions, ...options });
+    const options = { ...defaultOptions, ...optEnv };
+    const theme = compileTheme(flavor, options);
     writeFile(
       join(repoRoot, `themes/${flavor}.json`),
       JSON.stringify(theme, null, 2),


### PR DESCRIPTION
I mistakenly called the option `accentColor` when `accent` was needed; added a deprecation note.