### PR TITLE
feat(regex): add dedicated syntax highlighting for regex

### DIFF
--- a/packages/catppuccin-vsc/src/theme/tokens/index.ts
+++ b/packages/catppuccin-vsc/src/theme/tokens/index.ts
@@ -19,6 +19,7 @@ import markdown from "./markdown";
 import nix from "./nix";
 import php from "./php";
 import python from "./python";
+import regex from "./regex";
 import rust from "./rust";
 import shell from "./shell";
 
@@ -58,12 +59,6 @@ export default (context: ThemeContext): TextmateColors => {
       scope: ["string", "punctuation.definition.string"],
       settings: {
         foreground: palette.green,
-      },
-    },
-    {
-      scope: "string.regexp",
-      settings: {
-        foreground: palette.pink,
       },
     },
     {
@@ -306,6 +301,7 @@ export default (context: ThemeContext): TextmateColors => {
       nix,
       php,
       python,
+      regex,
       rust,
       shell,
     ].flatMap((el) => el(context)),

--- a/packages/catppuccin-vsc/src/theme/tokens/regex.ts
+++ b/packages/catppuccin-vsc/src/theme/tokens/regex.ts
@@ -5,6 +5,16 @@ const tokens = (context: ThemeContext): TextmateColors => {
 
   return [
     {
+      name: "Regex string begin/end in JS/TS",
+      scope: [
+        "string.regexp punctuation.definition.string.begin",
+        "string.regexp punctuation.definition.string.end",
+      ],
+      settings: {
+        foreground: palette.pink,
+      },
+    },
+    {
       name: "Regex anchors (^, $)",
       scope: "keyword.control.anchor.regexp",
       settings: {

--- a/packages/catppuccin-vsc/src/theme/tokens/regex.ts
+++ b/packages/catppuccin-vsc/src/theme/tokens/regex.ts
@@ -1,0 +1,80 @@
+import type { TextmateColors, ThemeContext } from "@/types";
+
+const tokens = (context: ThemeContext): TextmateColors => {
+  const { palette } = context;
+
+  return [
+    {
+      name: "Regex anchors (^, $)",
+      scope: "keyword.control.anchor.regexp",
+      settings: {
+        foreground: palette.mauve,
+      },
+    },
+    {
+      name: "Regex regular string match",
+      scope: "string.regexp.ts",
+      settings: {
+        foreground: palette.text,
+      },
+    },
+    {
+      name: "Regex group parenthesis & backreference (\\1, \\2, \\3, ...)",
+      scope: [
+        "punctuation.definition.group.regexp",
+        "keyword.other.back-reference.regexp",
+      ],
+      settings: {
+        foreground: palette.green,
+      },
+    },
+    {
+      name: "Regex character class []",
+      scope: "punctuation.definition.character-class.regexp",
+      settings: {
+        foreground: palette.yellow,
+      },
+    },
+    {
+      name: "Regex character classes (\\d, \\w, \\s)",
+      scope: "constant.other.character-class.regexp",
+      settings: {
+        foreground: palette.pink,
+      },
+    },
+    {
+      name: "Regex range",
+      scope: "constant.other.character-class.range.regexp",
+      settings: {
+        foreground: palette.rosewater,
+      },
+    },
+    {
+      name: "Regex quantifier",
+      scope: "keyword.operator.quantifier.regexp",
+      settings: {
+        foreground: palette.teal,
+      },
+    },
+    {
+      name: "Regex constant/numeric",
+      scope: "constant.character.numeric.regexp",
+      settings: {
+        foreground: palette.peach,
+      },
+    },
+    {
+      name: "Regex lookaheads, negative lookaheads, lookbehinds, negative lookbehinds",
+      scope: [
+        "punctuation.definition.group.no-capture.regexp",
+        "meta.assertion.look-ahead.regexp",
+        "meta.assertion.negative-look-ahead.regexp",
+      ],
+      settings: {
+        foreground: palette.blue,
+      },
+    },
+  ];
+};
+
+export default tokens;


### PR DESCRIPTION
Closes #255 

![image](https://github.com/catppuccin/vscode/assets/79978224/04c4c792-c739-440b-83f6-f6a58c1f8f7c)
