### PR TITLE
build: turn off code splitting

### DIFF
--- a/packages/catppuccin-vsc/build.ts
+++ b/packages/catppuccin-vsc/build.ts
@@ -19,7 +19,6 @@ const dev = getFlag("--dev", Boolean);
     external: ["vscode"],
     minify: !dev,
     sourcemap: dev,
-    splitting: true,
     target: "node16",
   });
 


### PR DESCRIPTION
It turns out that splitting caused some odd glitches when upgrading, like VSCode still referring to a differently named chunk, and thus being unable to load the extension.
This almost 2x's the build size, but I don't really have other ideas.