### PR TITLE
build: rename tag in schema URLs

### DIFF
--- a/packages/catppuccin-vsc/package.json
+++ b/packages/catppuccin-vsc/package.json
@@ -73,13 +73,13 @@
           "type": "object",
           "default": {},
           "markdownDescription": "Custom color overrides. Assign your own hex codes to palette colors. See [the docs](https://github.com/catppuccin/vscode#override-palette-colors) for reference.",
-          "$ref": "https://cdn.jsdelivr.net/gh/catppuccin/vscode@v3.9.0/packages/catppucin-vsc/schemas/colorOverrides.schema.json"
+          "$ref": "https://cdn.jsdelivr.net/gh/catppuccin/vscode@catppuccin-vsc-v3.10.0/packages/catppucin-vsc/schemas/colorOverrides.schema.json"
         },
         "catppuccin.customUIColors": {
           "type": "object",
           "default": {},
           "markdownDescription": "Customize UI colors. Map `workbench.colorCustomizations` to palette colors. See [the docs](https://github.com/catppuccin/vscode#use-palette-colors-on-workbench-elements-ui) for reference.",
-          "$ref": "https://cdn.jsdelivr.net/gh/catppuccin/vscode@v3.9.0/packages/catppuccin-vsc/schemas/customUIColors.schema.json"
+          "$ref": "https://cdn.jsdelivr.net/gh/catppuccin/vscode@catppuccin-vsc-v3.10.0/packages/catppuccin-vsc/schemas/customUIColors.schema.json"
         },
         "catppuccin.accentColor": {
           "type": "string",

--- a/packages/catppuccin-vsc/src/hooks/updatePackageJson.ts
+++ b/packages/catppuccin-vsc/src/hooks/updatePackageJson.ts
@@ -44,14 +44,14 @@ const configuration = (version: string) => {
         default: {},
         markdownDescription:
           "Custom color overrides. Assign your own hex codes to palette colors. See [the docs](https://github.com/catppuccin/vscode#override-palette-colors) for reference.",
-        $ref: `https://cdn.jsdelivr.net/gh/catppuccin/vscode@v${version}/packages/catppucin-vsc/schemas/colorOverrides.schema.json`,
+        $ref: `https://cdn.jsdelivr.net/gh/catppuccin/vscode@catppuccin-vsc-v${version}/packages/catppucin-vsc/schemas/colorOverrides.schema.json`,
       },
       "catppuccin.customUIColors": {
         type: "object",
         default: {},
         markdownDescription:
           "Customize UI colors. Map `workbench.colorCustomizations` to palette colors. See [the docs](https://github.com/catppuccin/vscode#use-palette-colors-on-workbench-elements-ui) for reference.",
-        $ref: `https://cdn.jsdelivr.net/gh/catppuccin/vscode@v${version}/packages/catppuccin-vsc/schemas/customUIColors.schema.json`,
+        $ref: `https://cdn.jsdelivr.net/gh/catppuccin/vscode@catppuccin-vsc-v${version}/packages/catppuccin-vsc/schemas/customUIColors.schema.json`,
       },
       "catppuccin.accentColor": {
         type: "string",


### PR DESCRIPTION
catppuccin-vsc v3.10.0 will be tagged as `catppuccin-vsc-v3.10.0` instead of `v3.10.0`, so this changes the tag accordingly.