### PR TITLE
feat(ui): add colors to activity bar when placed on top

### DIFF
--- a/packages/catppuccin-vsc/src/theme/uiColors.ts
+++ b/packages/catppuccin-vsc/src/theme/uiColors.ts
@@ -52,6 +52,10 @@ export const getUiColors = (
     "activityBar.activeBorder": transparent,
     "activityBar.activeBackground": transparent,
     "activityBar.activeFocusBorder": transparent,
+    "activityBarTop.foreground": accent,
+    "activityBarTop.activeBorder": transparent,
+    "activityBarTop.inactiveForeground": palette.overlay0,
+    "activityBarTop.dropBorder": dropBackground,
 
     "badge.background": palette.surface1,
     "badge.foreground": palette.text,


### PR DESCRIPTION
This PR fixes unthemed activity bar when its placed at the top.

Before :
![Screenshot 2024-02-09 190013](https://github.com/catppuccin/vscode/assets/95456933/350658b4-a768-4bc6-abaf-260d582440b1)
After :
![Screenshot 2024-02-09 190200](https://github.com/catppuccin/vscode/assets/95456933/40f0b1a9-2455-482c-b354-0379e0578619)
