### PR TITLE
docs: add details for CDN usage of json files

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,18 @@ Open the Command Palette and select "Extensions: Install from VSIX...", then ope
 
 **Using the JSON files**
 
-If you need to use the JSON files for libraries like [Shiki](https://www.npmjs.com/package/shiki) or [Shikiji](https://www.npmjs.com/package/shikiji), the theme files are published to NPM as [`@catppuccin/vscode`](https://www.npmjs.com/package/@catppuccin/vscode).
+If you need to use the JSON files for libraries like [Shiki](https://www.npmjs.com/package/shiki) or [Shikiji](https://www.npmjs.com/package/shikiji), the theme files are published to npm as [`@catppuccin/vscode`](https://www.npmjs.com/package/@catppuccin/vscode).
+
+You can use the following `esm.sh` CDN links to access them as well.
+
+| Flavor    | URL                                                     |
+| --------- | ------------------------------------------------------- |
+| Latte     | https://esm.sh/@catppuccin/vscode/themes/latte.json     |
+| Frappé    | https://esm.sh/@catppuccin/vscode/themes/frappe.json    |
+| Macchiato | https://esm.sh/@catppuccin/vscode/themes/macchiato.json |
+| Mocha     | https://esm.sh/@catppuccin/vscode/themes/mocha.json     |
+
+To tag them at a specific version, use a semver specifier such as `@catppuccin/vscode@3.10.0`.
 
 **Nix (Home-Manager) users**
 


### PR DESCRIPTION
The ShikiJS port [links to a scary deprecated branch](https://github.com/catppuccin/catppuccin/blob/main/resources/ports.yml#L843) of this repository and I thought it might be better to transfer the instructions from that README to the main one and update the `ports.yml` link to navigate away from the `compiled` branch.