### PR TITLE
fix: shim theme name for shiki

### DIFF
--- a/packages/catppuccin-vscode/src/index.ts
+++ b/packages/catppuccin-vscode/src/index.ts
@@ -1,6 +1,25 @@
-export { default as latte } from "catppuccin-vsc/themes/latte.json" with { type: "json" };
-export { default as frappe } from "catppuccin-vsc/themes/frappe.json" with { type: "json" };
-export { default as macchiato } from "catppuccin-vsc/themes/macchiato.json" with { type: "json" };
-export { default as mocha } from "catppuccin-vsc/themes/mocha.json" with { type: "json" };
+import latteJson from "catppuccin-vsc/themes/latte.json" with { type: "json" };
+import frappeJson from "catppuccin-vsc/themes/frappe.json" with { type: "json" };
+import macchiatoJson from "catppuccin-vsc/themes/macchiato.json" with { type: "json" };
+import mochaJson from "catppuccin-vsc/themes/mocha.json" with { type: "json" };
 
 export { compile } from "./compile.js";
+
+// shim the name for the Shiki theme, as the name is used for the className
+
+export const latte = {
+  ...latteJson,
+  name: "catppuccin-latte",
+};
+export const frappe = {
+  ...frappeJson,
+  name: "catppuccin-frappe",
+};
+export const macchiato = {
+  ...macchiatoJson,
+  name: "catppuccin-macchiato",
+};
+export const mocha = {
+  ...mochaJson,
+  name: "catppuccin-mocha",
+};


### PR DESCRIPTION
Without this fix, Shiki (at least in Astro) would generate wrong class names:

![2024-03-10-151804@2x](https://github.com/catppuccin/vscode/assets/79978224/23b19a26-fb15-455d-9f47-3f5967d159fe)

This could be fixed via
```ts
import { mocha } from "@catppuccin/vscode";
import { defineConfig } from "astro/config";

export default defineConfig({
  markdown: {
    shikiConfig: {
      theme: {
        ...mocha,
        name: "catppuccin-mocha",
      },
    },
  },
});
```

but it makes sense to shim this for the library user.