### PR TITLE
feat: rework selection background

### DIFF
--- a/packages/catppuccin-vsc/src/theme/uiColors.ts
+++ b/packages/catppuccin-vsc/src/theme/uiColors.ts
@@ -145,11 +145,12 @@ export const getUiColors = (
     "editor.lineHighlightBorder": transparent,
     "editor.rangeHighlightBackground": opacity(palette.sky, 0.25),
     "editor.rangeHighlightBorder": transparent,
-    "editor.selectionBackground": opacity(palette.surface2, 0.4),
-    "editor.selectionHighlightBackground": opacity(palette.overlay2, 0.4),
-    "editor.selectionHighlightBorder": opacity(palette.sky, 0.2),
-    "editor.wordHighlightBackground": opacity(palette.surface2, 0.7),
-    "editor.wordHighlightStrongBackground": opacity(palette.surface2, 0.5),
+
+    "editor.selectionBackground": opacity(palette.overlay2, 0.2),
+    "editor.selectionHighlightBackground": opacity(palette.overlay2, 0.2),
+    "editor.selectionHighlightBorder": opacity(palette.overlay2, 0.2),
+    "editor.wordHighlightBackground": opacity(palette.overlay2, 0.2),
+
     "editorBracketMatch.background": opacity(palette.overlay2, 0.1),
     "editorBracketMatch.border": palette.overlay2,
     "editorCodeLens.foreground": palette.overlay1,

--- a/packages/catppuccin-vsc/src/theme/uiColors.ts
+++ b/packages/catppuccin-vsc/src/theme/uiColors.ts
@@ -140,13 +140,15 @@ export const getUiColors = (
     "editor.foldBackground": opacity(palette.sky, 0.25),
     "editor.foreground": palette.text,
     "editor.hoverHighlightBackground": opacity(palette.sky, 0.25),
-    "editor.inactiveSelectionBackground": opacity(palette.surface2, 0.25),
     "editor.lineHighlightBackground": opacity(palette.text, 0.07),
     "editor.lineHighlightBorder": transparent,
     "editor.rangeHighlightBackground": opacity(palette.sky, 0.25),
     "editor.rangeHighlightBorder": transparent,
 
-    "editor.selectionBackground": opacity(palette.overlay2, 0.2),
+    "editor.selectionBackground": opacity(
+      palette.overlay2,
+      isLatte ? 0.3 : 0.25,
+    ),
     "editor.selectionHighlightBackground": opacity(palette.overlay2, 0.2),
     "editor.selectionHighlightBorder": opacity(palette.overlay2, 0.2),
     "editor.wordHighlightBackground": opacity(palette.overlay2, 0.2),


### PR DESCRIPTION
attempt nr 2 for #331 

![2024-03-10-221229@2x](https://github.com/catppuccin/vscode/assets/79978224/4c3bd140-96c1-4f61-866d-bbef1ae4eedc)
![2024-03-10-221152@2x](https://github.com/catppuccin/vscode/assets/79978224/98978c07-c2f1-434f-9d26-7711e2c06081)

latte might need a bump in opacity
