### PR TITLE
ci: mark theme release as latest

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -146,3 +146,18 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm publish --provenance
+
+  mark-vscode-theme-as-latest:
+    runs-on: ubuntu-latest
+
+    # always run after all other jobs
+    if: ${{ always() }}
+    needs:
+      - release-please
+      - release-vscode
+      - release-pack
+      - release-npm
+
+    steps:
+      - name: Mark VSCode theme release as latest release
+        run: gh release edit ${{ needs.release-please.outputs.theme_tag }} --latest


### PR DESCRIPTION
The syntax for this logic is so atrocious I really can't be bothered testing lmfao

Guess we'll find out on the next episode that is the shitshow of GitHub Actions