### PR TITLE
feat: add support for markdown in quarto documents

### DIFF
--- a/packages/catppuccin-vsc/src/theme/tokens/markdown.ts
+++ b/packages/catppuccin-vsc/src/theme/tokens/markdown.ts
@@ -8,6 +8,8 @@ const tokens = (context: ThemeContext): TextmateColors => {
       scope: [
         "heading.1.markdown punctuation.definition.heading.markdown",
         "heading.1.markdown",
+        "heading.1.quarto punctuation.definition.heading.quarto",
+        "heading.1.quarto",
         "markup.heading.atx.1.mdx",
         "markup.heading.atx.1.mdx punctuation.definition.heading.mdx",
         "markup.heading.setext.1.markdown",
@@ -21,6 +23,8 @@ const tokens = (context: ThemeContext): TextmateColors => {
       scope: [
         "heading.2.markdown punctuation.definition.heading.markdown",
         "heading.2.markdown",
+        "heading.2.quarto punctuation.definition.heading.quarto",
+        "heading.2.quarto",
         "markup.heading.atx.2.mdx",
         "markup.heading.atx.2.mdx punctuation.definition.heading.mdx",
         "markup.heading.setext.2.markdown",
@@ -34,6 +38,8 @@ const tokens = (context: ThemeContext): TextmateColors => {
       scope: [
         "heading.3.markdown punctuation.definition.heading.markdown",
         "heading.3.markdown",
+        "heading.3.quarto punctuation.definition.heading.quarto",
+        "heading.3.quarto",
         "markup.heading.atx.3.mdx",
         "markup.heading.atx.3.mdx punctuation.definition.heading.mdx",
         "markup.heading.heading-2.asciidoc",
@@ -46,6 +52,8 @@ const tokens = (context: ThemeContext): TextmateColors => {
       scope: [
         "heading.4.markdown punctuation.definition.heading.markdown",
         "heading.4.markdown",
+        "heading.4.quarto punctuation.definition.heading.quarto",
+        "heading.4.quarto",
         "markup.heading.atx.4.mdx",
         "markup.heading.atx.4.mdx punctuation.definition.heading.mdx",
         "markup.heading.heading-3.asciidoc",
@@ -58,6 +66,8 @@ const tokens = (context: ThemeContext): TextmateColors => {
       scope: [
         "heading.5.markdown punctuation.definition.heading.markdown",
         "heading.5.markdown",
+        "heading.5.quarto punctuation.definition.heading.quarto",
+        "heading.5.quarto",
         "markup.heading.atx.5.mdx",
         "markup.heading.atx.5.mdx punctuation.definition.heading.mdx",
         "markup.heading.heading-4.asciidoc",
@@ -70,6 +80,8 @@ const tokens = (context: ThemeContext): TextmateColors => {
       scope: [
         "heading.6.markdown punctuation.definition.heading.markdown",
         "heading.6.markdown",
+        "heading.6.quarto punctuation.definition.heading.quarto",
+        "heading.6.quarto",
         "markup.heading.atx.6.mdx",
         "markup.heading.atx.6.mdx punctuation.definition.heading.mdx",
         "markup.heading.heading-5.asciidoc",
@@ -110,12 +122,16 @@ const tokens = (context: ThemeContext): TextmateColors => {
       name: "Markdown links",
       scope: [
         "text.html.markdown punctuation.definition.link.title",
+        "text.html.quarto punctuation.definition.link.title",
         "string.other.link.title.markdown",
+        "string.other.link.title.quarto",
         "markup.link",
         // references like
         // > [1]: http://example.com "Example"
         "punctuation.definition.constant.markdown",
+        "punctuation.definition.constant.quarto",
         "constant.other.reference.link.markdown",
+        "constant.other.reference.link.quarto",
         "markup.substitution.attribute-reference",
       ],
       settings: {
@@ -126,8 +142,11 @@ const tokens = (context: ThemeContext): TextmateColors => {
       name: "Markdown code spans",
       scope: [
         "punctuation.definition.raw.markdown",
+        "punctuation.definition.raw.quarto",
         "markup.inline.raw.string.markdown",
+        "markup.inline.raw.string.quarto",
         "markup.raw.block.markdown",
+        "markup.raw.block.quarto",
       ],
       settings: {
         foreground: palette.green,
@@ -168,10 +187,18 @@ const tokens = (context: ThemeContext): TextmateColors => {
       name: "Markdown list bullets",
       scope: [
         "punctuation.definition.list.begin.markdown",
+        "punctuation.definition.list.begin.quarto",
         "markup.list.bullet",
       ],
       settings: {
         foreground: palette.teal,
+      },
+    },
+    {
+      name: "Quarto headings",
+      scope: "markup.heading.quarto",
+      settings: {
+        fontStyle: "bold",
       },
     },
   ];


### PR DESCRIPTION
This PR add support for markdown content in [quarto](https://quarto.org) document.

Quarto files have a slightly different naming scheme for scopes, and use the "quarto" suffix instead of markdown. This PR adds this suffix to `markdown.ts` when necessary. It also add a `fontStyle: "bold"` to the `markup.heading.quarto` scope in order to keep headings in bold as in regular markdown.

Many thanks for your work on catppuccin, the latte theme is one of my favourites.