### PR TITLE
feat: support `autoDetectColorScheme` in icon sync

### DIFF
--- a/packages/catppuccin-vsc/src/main.ts
+++ b/packages/catppuccin-vsc/src/main.ts
@@ -1,6 +1,6 @@
-import { ExtensionContext, Uri, workspace } from "vscode";
-import * as utils from "./utils";
+import { ExtensionContext, Uri, window, workspace } from "vscode";
 import type { ThemePaths } from "./types";
+import * as utils from "./utils";
 
 export const activate = async (context: ExtensionContext) => {
   const base = context.extensionUri;
@@ -28,11 +28,11 @@ export const activate = async (context: ExtensionContext) => {
           utils.UpdateTrigger.CONFIG_CHANGE,
         );
       }
-      // call the icon pack sync when the theme changes
-      if (
-        event.affectsConfiguration("workbench.colorTheme") &&
-        config.syncWithIconPack
-      ) {
+    }),
+
+    // call the icon pack sync when the theme changes
+    window.onDidChangeActiveColorTheme(() => {
+      if (config.syncWithIconPack) {
         utils.syncToIconPack();
       }
     }),


### PR DESCRIPTION
users can set their active color theme either with `workbench.colorTheme` or with `window.autoDetectColorScheme`.

in the latter case, four other settings control the theme that is enabled.

this commit updates the `syncToIconPack` function to take `autoDetectColorScheme` into account and correctly sync the icon theme when it's enabled.

fixes #398 (or rather a secondary issue that was raised there)