### PR TITLE
Fix desync between icon pack and color theme

### DIFF
--- a/packages/catppuccin-vsc/src/main.ts
+++ b/packages/catppuccin-vsc/src/main.ts
@@ -28,6 +28,13 @@ export const activate = async (context: ExtensionContext) => {
           utils.UpdateTrigger.CONFIG_CHANGE,
         );
       }
+      // call the icon pack sync when the config changes
+      if (
+        event.affectsConfiguration("workbench.colorTheme") &&
+        config.syncWithIconPack
+      ) {
+        utils.syncToIconPack();
+      }
     }),
 
     // call the icon pack sync when the theme changes


### PR DESCRIPTION
The root cause of the problem is that VS Code seems to fire the `onDidChangeActiveColorTheme` event **before** the config is persisted, thus our `syncToIconPack()` runs too early and in turn `getActiveTheme()` reads back the not-yet-updated theme from the configuration.

The fix is to listen for both the config change _and_ the active theme change (needed to handle the `autoDetectColorScheme` edge case).

Solves #430.