### PR TITLE
fix: include profile picture when built with nix

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -46,7 +46,7 @@
         runHook preInstall
         mkdir -p $out
         cd packages/catppuccin-vsc
-        cp -rL LICENSE README.md package.json dist/ themes/ $out/
+        cp -rL LICENSE README.md package.json icon.png dist/ themes/ $out/
         runHook postInstall
       '';
     };


### PR DESCRIPTION
The `icon.png` was missing from the nix built extension.