### PR TITLE
fix(nix): buildVscodeExtension requires pname

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1712963716,
-        "narHash": "sha256-WKm9CvgCldeIVvRz87iOMi8CFVB1apJlkUT4GGvA0iM=",
+        "lastModified": 1732837521,
+        "narHash": "sha256-jNRNr49UiuIwaarqijgdTR2qLPifxsVhlJrKzQ8XUIE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "cfd6b5fc90b15709b780a5a1619695a88505a176",
+        "rev": "970e93b9f82e2a0f3675757eb0bfc73297cc6370",
         "type": "github"
       },
       "original": {

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -19,12 +19,12 @@
   validWorkbenchModes = properties."catppuccin.workbenchMode".enum;
   validBracketModes = properties."catppuccin.bracketMode".enum;
 
-  inherit (packageJSON) name version;
-  pname = "${name}-${version}";
+  inherit (packageJSON) version;
+  pname = packageJSON.name;
 
   options = builtins.removeAttrs inputs ["pkgs"];
   src = pkgs.nix-gitignore.gitignoreSource [] (builtins.path {
-    name = pname;
+    name = "${pname}-${version}";
     path = ../.;
   });
 
@@ -52,7 +52,7 @@
     };
   };
   vscodeExtPublisher = "catppuccin";
-  vscodeExtName = name;
+  vscodeExtName = pname;
   vscodeExtUniqueId = "${vscodeExtPublisher}.${vscodeExtName}";
 in
   (lib.throwIfNot (accentColor == null) "${pname}: deprecated option 'accentColor' is no longer supported, please use 'accent' instead.")
@@ -60,7 +60,7 @@ in
   (lib.checkListOfEnum "${pname}: workbenchMode" validWorkbenchModes [workbenchMode])
   (lib.checkListOfEnum "${pname}: bracketMode" validBracketModes [bracketMode])
   (pkgs.vscode-utils.buildVscodeExtension {
-    inherit name version vscodeExtPublisher vscodeExtName vscodeExtUniqueId;
+    inherit pname version vscodeExtPublisher vscodeExtName vscodeExtUniqueId;
     src = builder.outPath;
 
     buildInputs = [pkgs.nodejs];


### PR DESCRIPTION
Breaks on current nixos-unstable channel.

- https://github.com/NixOS/nixpkgs/pull/354740
- `vscode-utils.buildVscodeExtension` now requires pname as an argument