### PR TITLE
Fix build error on latest unstable nixpkgs

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -60,7 +60,7 @@ in
   (lib.checkListOfEnum "${pname}: workbenchMode" validWorkbenchModes [workbenchMode])
   (lib.checkListOfEnum "${pname}: bracketMode" validBracketModes [bracketMode])
   (pkgs.vscode-utils.buildVscodeExtension {
-    inherit name version vscodeExtPublisher vscodeExtName vscodeExtUniqueId;
+    inherit name pname version vscodeExtPublisher vscodeExtName vscodeExtUniqueId;
     src = builder.outPath;
 
     buildInputs = [pkgs.nodejs];


### PR DESCRIPTION
On latest unstable nixpkgs, the build fails with the following error :
```
error: function 'buildVscodeExtension' called without required argument 'pname'
```
this fixes the error :+1: 