### PR TITLE
fix(tokens/markdown): match headings 5 & 6 to style guide

### DIFF
--- a/packages/catppuccin-vsc/src/theme/tokens/markdown.ts
+++ b/packages/catppuccin-vsc/src/theme/tokens/markdown.ts
@@ -73,7 +73,7 @@ const tokens = (context: ThemeContext): TextmateColors => {
         "markup.heading.heading-4.asciidoc",
       ],
       settings: {
-        foreground: palette.blue,
+        foreground: palette.sapphire,
       },
     },
     {
@@ -87,7 +87,7 @@ const tokens = (context: ThemeContext): TextmateColors => {
         "markup.heading.heading-5.asciidoc",
       ],
       settings: {
-        foreground: palette.mauve,
+        foreground: palette.lavender,
       },
     },
     {


### PR DESCRIPTION
As mentioned in Discord, these new colors are what the style guide specifies:

![image](https://github.com/user-attachments/assets/c68d6546-0c6d-41e3-9940-2d993006852a)
