### PR TITLE
fix(tokens/python): mauve builtin types, peach language constants

### DIFF
--- a/packages/catppuccin-vsc/src/theme/tokens/python.ts
+++ b/packages/catppuccin-vsc/src/theme/tokens/python.ts
@@ -96,14 +96,14 @@ const tokens = (context: ThemeContext): TextmateColors => {
       name: "entity.name.type",
       scope: ["support.type.python"],
       settings: {
-        foreground: palette.peach,
+        foreground: palette.mauve,
       },
     },
     {
       name: "python constants (True/False)",
       scope: "constant.language.python",
       settings: {
-        foreground: palette.mauve,
+        foreground: palette.peach,
       },
     },
     {


### PR DESCRIPTION
Makes Python more in line with how we highlight every other language.