### PR TITLE
refactor: stop building for Azure Data Studio

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,9 +20,7 @@ jobs:
         run: pnpm lint
 
       - name: Build
-        run: |
-          pnpm --filter catppuccin-vsc core:build
-          pnpm --filter catppuccin-vsc core:build-ads
+        run: pnpm --filter catppuccin-vsc core:build
 
       - name: Upload Artifact
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -68,10 +68,6 @@ jobs:
         id: build-vscode
         run: pnpm --filter catppuccin-vsc core:build
 
-      - name: Build Azure Data Studio
-        id: build-ads
-        run: pnpm --filter catppuccin-vsc core:build-ads
-
       - name: Publish to Visual Studio Marketplace
         working-directory: ./packages/catppuccin-vsc
         run: |

--- a/packages/catppuccin-vsc/build.ts
+++ b/packages/catppuccin-vsc/build.ts
@@ -6,11 +6,10 @@ import { getFlag } from "type-flag";
 import updatePackageJson from "@/hooks/updatePackageJson";
 import generateThemes from "@/hooks/generateThemes";
 
-const buildForADS = getFlag("--ads", Boolean);
 const development = getFlag("--dev", Boolean);
 
 await generateThemes();
-const packageJson = await updatePackageJson({ buildForADS });
+const packageJson = await updatePackageJson();
 
 await build({
   clean: true,
@@ -21,12 +20,9 @@ await build({
   target: "node16",
 });
 
-const shortName = buildForADS ? "ads" : "vsc";
-const packagePath = `catppuccin-${shortName}-${packageJson.version}.vsix`;
+const packagePath = `catppuccin-vsc-${packageJson.version}.vsix`;
 
 await createVSIX({ dependencies: false, packagePath });
 
-// restore the original package.json after building ADS
-if (buildForADS) await updatePackageJson();
 // the upload step in the CI required the path to the vsix file
 if (process.env.GITHUB_ACTIONS) setOutput("vsixPath", packagePath);

--- a/packages/catppuccin-vsc/package.json
+++ b/packages/catppuccin-vsc/package.json
@@ -183,7 +183,6 @@
   },
   "scripts": {
     "core:build": "tsx build.ts",
-    "core:build-ads": "tsx build.ts --ads",
     "core:dev": "tsx build.ts --dev",
     "schema:ui": "tsx src/hooks/updateSchemas.ts"
   },

--- a/packages/catppuccin-vsc/src/hooks/updatePackageJson.ts
+++ b/packages/catppuccin-vsc/src/hooks/updatePackageJson.ts
@@ -98,16 +98,12 @@ const configuration = (version: string) => {
   };
 };
 
-const main = async (options: { buildForADS?: boolean } = {}) => {
-  const productName = options.buildForADS ? "Azure Data Studio" : "VSCode";
-
+const main = async () => {
   return await readFile(path.join(repoRoot, "package.json"), "utf8")
     .then((data) => JSON.parse(data))
     .then((data) => {
       return {
         ...data,
-        displayName: `Catppuccin for ${productName}`,
-        description: `🦌 Soothing pastel theme for ${productName}`,
         contributes: {
           ...data.contributes,
           configuration: configuration(data.version),


### PR DESCRIPTION
As announced in the ["What's happening to Azure Data Studio? - Microsoft"](https://learn.microsoft.com/en-gb/azure-data-studio/whats-happening-azure-data-studio) article, Azure Data Studio has been retired and will no longer be supported past February 28th 2026.

This PR removes support for building on Azure Data Studio, simplifying our build process even more and making local development easier as we no longer have to "rehydrate" the `package.json` twice on each build.