### PR TITLE
fix(ui): increase diff contrast

### DIFF
--- a/packages/catppuccin-vsc/src/theme/uiColors.ts
+++ b/packages/catppuccin-vsc/src/theme/uiColors.ts
@@ -122,8 +122,8 @@ export const getUiColors = (
     "debugConsoleInputIcon.foreground": palette.text,
 
     "diffEditor.border": palette.surface2,
-    "diffEditor.insertedTextBackground": opacity(palette.green, 0.1),
-    "diffEditor.removedTextBackground": opacity(palette.red, 0.1),
+    "diffEditor.insertedTextBackground": opacity(palette.green, 0.2),
+    "diffEditor.removedTextBackground": opacity(palette.red, 0.2),
     "diffEditor.insertedLineBackground": opacity(palette.green, 0.15),
     "diffEditor.removedLineBackground": opacity(palette.red, 0.15),
     "diffEditor.diagonalFill": opacity(palette.surface2, 0.6),


### PR DESCRIPTION
Increases the diff contrast between removed/inserted text background and removed/inserted line background.

`Latte (Before)`
![image](https://github.com/user-attachments/assets/f15adb18-dbff-47bd-8dd7-0a38010de23b)
`Latte (After)`
![image](https://github.com/user-attachments/assets/94478579-5033-494f-b4fc-4ac0157d66ff)

`Mocha (Before)`
![image](https://github.com/user-attachments/assets/2dc44e02-aa7a-48d5-b431-961db4be06ef)
`Mocha (After)`
![image](https://github.com/user-attachments/assets/10976a82-c9bb-4f56-aae6-c037c002b933)

Closes #484 