### PR TITLE
fix(tokens): consistently style typst headings

### DIFF
--- a/packages/catppuccin-vsc/src/theme/tokens/index.ts
+++ b/packages/catppuccin-vsc/src/theme/tokens/index.ts
@@ -23,6 +23,7 @@ import python from "./python";
 import regex from "./regex";
 import rust from "./rust";
 import shell from "./shell";
+import typst from "./typst";
 
 export default function tokens(context: ThemeContext): TextmateColors {
   const { options, palette } = context;
@@ -306,6 +307,7 @@ export default function tokens(context: ThemeContext): TextmateColors {
       regex,
       rust,
       shell,
+      typst,
     ].flatMap((element) => element(context)),
   ];
 }

--- a/packages/catppuccin-vsc/src/theme/tokens/typst.ts
+++ b/packages/catppuccin-vsc/src/theme/tokens/typst.ts
@@ -1,0 +1,16 @@
+import type { TextmateColors, ThemeContext } from "@/types";
+
+const tokens = (context: ThemeContext): TextmateColors => {
+  const { palette } = context;
+
+  return [
+    {
+      scope: ["markup.heading.typst"],
+      settings: {
+        foreground: palette.red,
+      },
+    },
+  ];
+};
+
+export default tokens;


### PR DESCRIPTION
Closes #505 

Tested with a sample file:
<img width="534" alt="image" src="https://github.com/user-attachments/assets/1d65ba3e-450a-4e64-b58f-acd9acc3a512" />