### PR TITLE
fix: specify `scope: application` for all settings

### DIFF
--- a/packages/catppuccin-vsc/package.json
+++ b/packages/catppuccin-vsc/package.json
@@ -56,33 +56,39 @@
       "title": "Catppuccin",
       "properties": {
         "catppuccin.boldKeywords": {
+          "scope": "application",
           "type": "boolean",
           "default": true,
           "markdownDescription": "Controls whether to use **bold** for keywords."
         },
         "catppuccin.italicComments": {
+          "scope": "application",
           "type": "boolean",
           "default": true,
           "markdownDescription": "Controls whether to use *italics* for comments."
         },
         "catppuccin.italicKeywords": {
+          "scope": "application",
           "type": "boolean",
           "default": true,
           "markdownDescription": "Controls whether to use *italics* for keywords."
         },
         "catppuccin.colorOverrides": {
+          "scope": "application",
           "type": "object",
           "default": {},
           "markdownDescription": "Custom color overrides. Assign your own hex codes to palette colors. See [the docs](https://github.com/catppuccin/vscode#override-palette-colors) for reference.",
           "$ref": "https://esm.sh/gh/catppuccin/vscode@catppuccin-vsc-v3.16.1/packages/catppuccin-vsc/schemas/colorOverrides.schema.json"
         },
         "catppuccin.customUIColors": {
+          "scope": "application",
           "type": "object",
           "default": {},
           "markdownDescription": "Customize UI colors. Map `workbench.colorCustomizations` to palette colors. See [the docs](https://github.com/catppuccin/vscode#use-palette-colors-on-workbench-elements-ui) for reference.",
           "$ref": "https://esm.sh/gh/catppuccin/vscode@catppuccin-vsc-v3.16.1/packages/catppuccin-vsc/schemas/customUIColors.schema.json"
         },
         "catppuccin.accentColor": {
+          "scope": "application",
           "type": "string",
           "default": "mauve",
           "description": "Controls which accent color to use.",
@@ -104,6 +110,7 @@
           ]
         },
         "catppuccin.workbenchMode": {
+          "scope": "application",
           "type": "string",
           "default": "default",
           "description": "Controls how the workbench should be styled.",
@@ -119,6 +126,7 @@
           ]
         },
         "catppuccin.bracketMode": {
+          "scope": "application",
           "type": "string",
           "default": "rainbow",
           "description": "Controls how bracket pairs should be themed",
@@ -136,11 +144,13 @@
           ]
         },
         "catppuccin.extraBordersEnabled": {
+          "scope": "application",
           "type": "boolean",
           "default": false,
           "description": "Controls whether borders should be enabled on some additional UI elements."
         },
         "catppuccin.syncWithIconPack": {
+          "scope": "application",
           "type": "boolean",
           "default": true,
           "markdownDescription": "Controls whether to sync the currently active Catppuccin flavor with the [Catppuccin Icon Pack](https://github.com/catppuccin/vscode-icons)"

--- a/packages/catppuccin-vsc/src/hooks/packageJson.ts
+++ b/packages/catppuccin-vsc/src/hooks/packageJson.ts
@@ -25,21 +25,25 @@ const configuration = (version: string) => {
     title: "Catppuccin",
     properties: {
       "catppuccin.boldKeywords": {
+        scope: "application",
         type: "boolean",
         default: true,
         markdownDescription: "Controls whether to use **bold** for keywords.",
       },
       "catppuccin.italicComments": {
+        scope: "application",
         type: "boolean",
         default: true,
         markdownDescription: "Controls whether to use *italics* for comments.",
       },
       "catppuccin.italicKeywords": {
+        scope: "application",
         type: "boolean",
         default: true,
         markdownDescription: "Controls whether to use *italics* for keywords.",
       },
       "catppuccin.colorOverrides": {
+        scope: "application",
         type: "object",
         default: {},
         markdownDescription:
@@ -47,6 +51,7 @@ const configuration = (version: string) => {
         $ref: `https://esm.sh/gh/catppuccin/vscode@catppuccin-vsc-v${version}/packages/catppuccin-vsc/schemas/colorOverrides.schema.json`,
       },
       "catppuccin.customUIColors": {
+        scope: "application",
         type: "object",
         default: {},
         markdownDescription:
@@ -54,12 +59,14 @@ const configuration = (version: string) => {
         $ref: `https://esm.sh/gh/catppuccin/vscode@catppuccin-vsc-v${version}/packages/catppuccin-vsc/schemas/customUIColors.schema.json`,
       },
       "catppuccin.accentColor": {
+        scope: "application",
         type: "string",
         default: "mauve",
         description: "Controls which accent color to use.",
         enum: accents,
       },
       "catppuccin.workbenchMode": {
+        scope: "application",
         type: "string",
         default: "default",
         description: "Controls how the workbench should be styled.",
@@ -71,6 +78,7 @@ const configuration = (version: string) => {
         ],
       },
       "catppuccin.bracketMode": {
+        scope: "application",
         type: "string",
         default: "rainbow",
         description: "Controls how bracket pairs should be themed",
@@ -83,12 +91,14 @@ const configuration = (version: string) => {
         ],
       },
       "catppuccin.extraBordersEnabled": {
+        scope: "application",
         type: "boolean",
         default: false,
         description:
           "Controls whether borders should be enabled on some additional UI elements.",
       },
       "catppuccin.syncWithIconPack": {
+        scope: "application",
         type: "boolean",
         default: true,
         markdownDescription:


### PR DESCRIPTION
Relates to https://github.com/catppuccin/vscode/issues/452

The theme customisation is implemented in such a way where the only valid scope is `application`. This will reduce user confusion if they try to configure this in their profile or workspace.

E.g.

![image](https://github.com/user-attachments/assets/f4beef21-7d6c-4fd2-9b39-cb35b97f7e53)
