### PR TITLE
Remove console log in production

### DIFF
--- a/packages/catppuccin-vsc/src/hooks/generateThemes.ts
+++ b/packages/catppuccin-vsc/src/hooks/generateThemes.ts
@@ -33,6 +33,5 @@ const main = async () => {
 
 export default main;
 if (typeof require !== "undefined" && require.main === module) {
-  console.log("Compiling themes...");
   main();
 }

--- a/packages/catppuccin-vsc/src/utils.ts
+++ b/packages/catppuccin-vsc/src/utils.ts
@@ -79,13 +79,10 @@ export const isMutable = async (uri: Uri): Promise<boolean> => {
 export const isFreshInstall = async (
   context: ExtensionContext,
 ): Promise<boolean | "error"> => {
-  console.log("Checking if catppuccin is installed for the first time.");
   const flagUri = Uri.file(context.asAbsolutePath("themes/.flag"));
   if (await fileExists(flagUri)) {
-    console.log("Catppuccin has been installed before.");
     return false;
   } else {
-    console.log("Catppuccin is installed for the first time!");
     return workspace.fs.writeFile(flagUri, Buffer.from("")).then(
       () => true,
       () => "error",
@@ -94,10 +91,8 @@ export const isFreshInstall = async (
 };
 
 export const isDefaultConfig = (): boolean => {
-  console.log("Checking if catppuccin is using default config.");
   const state =
     JSON.stringify(getConfiguration()) === JSON.stringify(defaultOptions);
-  console.log(`Catppuccin is using ${state ? "default" : "custom"} config.`);
 
   return state;
 };


### PR DESCRIPTION
This pull request focuses on cleaning up unnecessary logging statements in the codebase to streamline the output and improve readability. The changes primarily involve removing `console.log` statements from several utility functions and the main entry point.

### Logging cleanup:

* [`packages/catppuccin-vsc/src/hooks/generateThemes.ts`](diffhunk://#diff-4881000fe3b4246c4e9b899a0413bf215c564b41b3f99430fc06c5a5b26c579fL36): Removed a `console.log` statement that logged "Compiling themes..." in the main entry point function.
* [`packages/catppuccin-vsc/src/utils.ts`](diffhunk://#diff-f4268c7cffb37545105a0db5d14ca4f5a0c0fca16486fc0b2aad14bbb5797e25L82-L88): Removed multiple `console.log` statements from the `isFreshInstall` function, which previously logged messages about the installation state of Catppuccin.
* [`packages/catppuccin-vsc/src/utils.ts`](diffhunk://#diff-f4268c7cffb37545105a0db5d14ca4f5a0c0fca16486fc0b2aad14bbb5797e25L97-L100): Removed `console.log` statements from the `isDefaultConfig` function, which previously logged whether the default configuration was being used.