### PR TITLE
feat: support built-in git scm graph

### DIFF
--- a/packages/catppuccin-vsc/src/theme/uiColors.ts
+++ b/packages/catppuccin-vsc/src/theme/uiColors.ts
@@ -277,6 +277,15 @@ export const getUiColors = (
     "gitDecoration.stageModifiedResourceForeground": palette.yellow,
     "gitDecoration.submoduleResourceForeground": palette.blue,
     "gitDecoration.untrackedResourceForeground": palette.green,
+    // git colors -> built-in git graph
+    "scmGraph.historyItemRefColor": palette.blue,
+    "scmGraph.historyItemBaseRefColor": palette.peach,
+    "scmGraph.historyItemRemoteRefColor": palette.mauve,
+    "scmGraph.foreground1": palette.yellow,
+    "scmGraph.foreground2": palette.red,
+    "scmGraph.foreground3": palette.green,
+    "scmGraph.foreground4": palette.mauve,
+    "scmGraph.foreground5": palette.teal,
 
     "input.background": palette.surface0,
     "input.border": transparent,


### PR DESCRIPTION
This project already has support for the super fancy graph from the excellent GitLens extension.

But what about us normies who also use the built-in SCM Graph?

This PR adds support for the poor-man's GitLens graph.

| Before | After |
|--------|--------|
|<img width="630" height="647" alt="Screenshot 2025-08-05 at 13 49 51" src="https://github.com/user-attachments/assets/fccd459a-be05-4116-b530-45c569dc2fb6" />|<img width="631" height="645" alt="Screenshot 2025-08-05 at 13 59 55" src="https://github.com/user-attachments/assets/3ded8a62-d578-4648-91f6-06f246d0851d" />|