### PR TITLE
fix(scripts): add `--no-regenerate` flag to help avoid flaky builds

### DIFF
--- a/packages/catppuccin-vsc/build.ts
+++ b/packages/catppuccin-vsc/build.ts
@@ -7,11 +7,12 @@ import { updatePackageJson, readPackageJsonVersion } from "@/hooks/packageJson";
 import generateThemes from "@/hooks/generateThemes";
 
 const development = getFlag("--dev", Boolean);
+const shouldRegenerate = !getFlag("--no-regenerate", Boolean);
 
 await generateThemes();
 
 const packageJsonVersion = await readPackageJsonVersion();
-if (!development) {
+if (shouldRegenerate) {
   console.debug(
     `Regenerating package.json with version "${packageJsonVersion}"`,
   );

--- a/packages/catppuccin-vsc/package.json
+++ b/packages/catppuccin-vsc/package.json
@@ -193,8 +193,8 @@
   },
   "scripts": {
     "core:build": "tsx build.ts",
-    "core:dev": "tsx build.ts --dev",
-    "core:watch": "tsx watch build.ts --dev",
+    "core:dev": "tsx build.ts --dev --no-regenerate",
+    "core:watch": "tsx watch build.ts --dev --no-regenerate",
     "schema:ui": "tsx src/hooks/updateSchemas.ts"
   },
   "homepage": "https://github.com/catppuccin/vscode/tree/main/packages/catppuccin-vsc#readme"


### PR DESCRIPTION

Not a big fan of inverting a negative flag, but this is the least amount of
work to make ctp/nix's life easier.

Closes #520
