### PR TITLE
fix(r-language): function calls are `blue`

### DIFF
--- a/packages/catppuccin-vsc/src/theme/tokens/index.ts
+++ b/packages/catppuccin-vsc/src/theme/tokens/index.ts
@@ -20,6 +20,7 @@ import markdown from "./markdown";
 import nix from "./nix";
 import php from "./php";
 import python from "./python";
+import r from "./r";
 import regex from "./regex";
 import rust from "./rust";
 import shell from "./shell";
@@ -307,6 +308,7 @@ export default function tokens(context: ThemeContext): TextmateColors {
       nix,
       php,
       python,
+      r,
       regex,
       rust,
       shell,

--- a/packages/catppuccin-vsc/src/theme/tokens/r.ts
+++ b/packages/catppuccin-vsc/src/theme/tokens/r.ts
@@ -1,0 +1,24 @@
+import type { TextmateColors, ThemeContext } from "@/types";
+
+const tokens = (context: ThemeContext): TextmateColors => {
+  const { palette } = context;
+
+  return [
+    {
+      name: "R function calls",
+      scope: "meta.function-call.r",
+      settings: {
+        foreground: palette.blue,
+      },
+    },
+    {
+      name: "R function call arguments",
+      scope: "meta.function-call.arguments.r",
+      settings: {
+        foreground: palette.text,
+      },
+    },
+  ];
+};
+
+export default tokens;


### PR DESCRIPTION
Closes #576


BEGIN_COMMIT_OVERRIDE
fix(tokens/r-language): ensure function calls are `blue`
END_COMMIT_OVERRIDE