### PR TITLE
fix: improve textCodeBlock visibility in hover tooltips

### DIFF
--- a/packages/catppuccin-vsc/src/theme/uiColors.ts
+++ b/packages/catppuccin-vsc/src/theme/uiColors.ts
@@ -31,7 +31,7 @@ export const getUiColors = (
     // Text colors
     "textBlockQuote.background": palette.mantle,
     "textBlockQuote.border": palette.crust,
-    "textCodeBlock.background": palette.mantle,
+    "textCodeBlock.background": palette.surface0,
     "textLink.activeForeground": palette.sky,
     "textLink.foreground": palette.blue,
     "textPreformat.foreground": palette.text,


### PR DESCRIPTION
## Problem

  #495 changed `textCodeBlock.background` to `palette.mantle` to fix codeblock visibility in Markdown preview (see #492).

  However, `editorHoverWidget.background` is also set to `mantle`, which means inline code in hover tooltips (e.g., parameter
  names like `argv` in documentation comments) became invisible - same background color, no contrast.

  ## Solution

  Change `textCodeBlock.background` from `palette.mantle` to `palette.surface0`.

  This provides proper contrast in both contexts:
  - **Markdown preview**: `surface0` vs `base` ✅
  - **Hover tooltips**: `surface0` vs `mantle` ✅

  ## Testing

  Tested locally with C documentation comments containing backticks (e.g., `@param argv`). Inline code is now clearly visible in
  hover tooltips.

  Related: #492, #495

  ## Before
<img width="854" height="350" alt="image" src="https://github.com/user-attachments/assets/58034d20-c3a5-423d-982c-09991eb48489" />

  ## After
<img width="846" height="329" alt="image" src="https://github.com/user-attachments/assets/102e06bf-f5aa-4c99-97dc-9878db529dc9" />


