### PR TITLE
fix(#434): add IME/pre-edit colors to fix font ghosting

### DIFF
--- a/packages/catppuccin-vsc-typegen/types/workbench-colors.d.ts
+++ b/packages/catppuccin-vsc-typegen/types/workbench-colors.d.ts
@@ -648,6 +648,27 @@ export interface WorkbenchColors {
    * Editor background color.
    */
   "editor.background"?: _1 | _19;
+
+  /**
+   * The background color of the IME composition.
+   */
+  "editor.imeBackground"?: _1 | string;
+  /**
+   * The foreground color of the IME composition.
+   */
+  "editor.imeForeground"?: _1 | string;
+  /**
+   * The border color of the IME composition.
+   */
+  "editor.imeBorder"?: _1 | string;
+  /**
+   * The background color of a composition.
+   */
+  "editor.compositionBackground"?: _1 | string;
+  /**
+   * The foreground color of a composition.
+   */
+  "editor.compositionForeground"?: _1 | string;
   /**
    * The border color for an IME composition.
    */

--- a/packages/catppuccin-vsc/src/theme/uiColors.ts
+++ b/packages/catppuccin-vsc/src/theme/uiColors.ts
@@ -1,9 +1,11 @@
-import type { ThemeContext } from "@/types";
+import type { ThemeContext, WorkbenchColors } from "@/types";
 import { mix, opacity, shade, transparent } from "./utilities";
 import extensions from "./extensions";
 import uiCustomizations from "./ui";
 
-export const getUiColors = (context: ThemeContext): Record<string, string> => {
+export const getUiColors = (
+  context: ThemeContext,
+): Partial<Record<keyof WorkbenchColors, string>> => {
   const { palette, paletteAnsi, options, isLatte } = context;
 
   const accent = palette[options.accent];
@@ -12,6 +14,8 @@ export const getUiColors = (context: ThemeContext): Record<string, string> => {
     ? opacity(palette.overlay1, 0.15)
     : transparent;
 
+  // find the definitions here:
+  // https://code.visualstudio.com/api/references/theme-color
   return {
     // Base colors
     focusBorder: accent,
@@ -32,20 +36,6 @@ export const getUiColors = (context: ThemeContext): Record<string, string> => {
     "textLink.foreground": palette.blue,
     "textPreformat.foreground": palette.text,
     "textSeparator.foreground": accent,
-
-    // CRITICAL FIX FOR #434: IME/Pre-Edit Text Colors
-    "editor.imeBackground": opacity(palette.mantle, 0.85),
-    "editor.imeForeground": palette.text,
-    "editor.imeBorder": accent,
-    "editor.compositionBackground": opacity(palette.surface1, 0.9),
-    "editor.compositionForeground": palette.text,
-    "editor.compositionBorder": opacity(accent, 0.4),
-    "editor.compositionSelectionBackground": opacity(palette.surface2, 0.4),
-    "editor.compositionSelectionForeground": palette.text,
-    "editor.compositionCueBackground": opacity(palette.surface1, 0.7),
-    "editor.compositionCueForeground": palette.subtext1,
-    "editor.compositionCueBorder": palette.surface2,
-    "editor.placeholder.foreground": palette.overlay1,
 
     // Activity Bar
     "activityBar.background": palette.crust,
@@ -311,16 +301,16 @@ export const getUiColors = (context: ThemeContext): Record<string, string> => {
     "inputValidation.warningForeground": palette.crust,
 
     // Lists and trees
-    "list.activeSelectionBackground": palette.surface0,
+    "list.activeSelectionBackground": palette.surface0, // currently selected in file tree
     "list.activeSelectionForeground": palette.text,
     "list.dropBackground": dropBackground,
-    "list.focusBackground": palette.surface0,
+    "list.focusBackground": palette.surface0, // when using keyboard to move around files
     "list.focusForeground": palette.text,
     "list.focusOutline": transparent,
     "list.highlightForeground": accent,
-    "list.hoverBackground": opacity(palette.surface0, 0.5),
+    "list.hoverBackground": opacity(palette.surface0, 0.5), // when hovering over the file tree
     "list.hoverForeground": palette.text,
-    "list.inactiveSelectionBackground": palette.surface0,
+    "list.inactiveSelectionBackground": palette.surface0, // currently selected focused in editor
     "list.inactiveSelectionForeground": palette.text,
     "list.warningForeground": palette.peach,
     "listFilterWidget.background": palette.surface1,
@@ -434,14 +424,18 @@ export const getUiColors = (context: ThemeContext): Record<string, string> => {
     "statusBar.background": palette.crust,
     "statusBar.foreground": palette.text,
     "statusBar.border": border,
+    // having no folder open shouldn't change the bar
     "statusBar.noFolderBackground": palette.crust,
     "statusBar.noFolderForeground": palette.text,
     "statusBar.noFolderBorder": border,
+    // debugging is peach
     "statusBar.debuggingBackground": palette.peach,
     "statusBar.debuggingForeground": palette.crust,
     "statusBar.debuggingBorder": border,
+    // remote is blue
     "statusBarItem.remoteBackground": palette.blue,
     "statusBarItem.remoteForeground": palette.crust,
+    // different states
     "statusBarItem.activeBackground": opacity(palette.surface2, 0.4),
     "statusBarItem.hoverBackground": opacity(palette.surface2, 0.2),
     "statusBarItem.prominentForeground": accent,
@@ -483,22 +477,22 @@ export const getUiColors = (context: ThemeContext): Record<string, string> => {
 
     // Terminal
     "terminal.foreground": palette.text,
-    "terminal.ansiBlack": paletteAnsi.normal.black,
-    "terminal.ansiRed": paletteAnsi.normal.red,
-    "terminal.ansiGreen": paletteAnsi.normal.green,
-    "terminal.ansiYellow": paletteAnsi.normal.yellow,
-    "terminal.ansiBlue": paletteAnsi.normal.blue,
-    "terminal.ansiMagenta": paletteAnsi.normal.magenta,
-    "terminal.ansiCyan": paletteAnsi.normal.cyan,
-    "terminal.ansiWhite": paletteAnsi.normal.white,
-    "terminal.ansiBrightBlack": paletteAnsi.bright.black,
-    "terminal.ansiBrightRed": paletteAnsi.bright.red,
-    "terminal.ansiBrightGreen": paletteAnsi.bright.green,
-    "terminal.ansiBrightYellow": paletteAnsi.bright.yellow,
-    "terminal.ansiBrightBlue": paletteAnsi.bright.blue,
-    "terminal.ansiBrightMagenta": paletteAnsi.bright.magenta,
-    "terminal.ansiBrightCyan": paletteAnsi.bright.cyan,
-    "terminal.ansiBrightWhite": paletteAnsi.bright.white,
+    "terminal.ansiBlack": paletteAnsi.normal.black, // color0
+    "terminal.ansiRed": paletteAnsi.normal.red, // color1
+    "terminal.ansiGreen": paletteAnsi.normal.green, // color2
+    "terminal.ansiYellow": paletteAnsi.normal.yellow, // color3
+    "terminal.ansiBlue": paletteAnsi.normal.blue, // color4
+    "terminal.ansiMagenta": paletteAnsi.normal.magenta, // color5
+    "terminal.ansiCyan": paletteAnsi.normal.cyan, // color6
+    "terminal.ansiWhite": paletteAnsi.normal.white, // color7
+    "terminal.ansiBrightBlack": paletteAnsi.bright.black, // color8
+    "terminal.ansiBrightRed": paletteAnsi.bright.red, // color9
+    "terminal.ansiBrightGreen": paletteAnsi.bright.green, // color10
+    "terminal.ansiBrightYellow": paletteAnsi.bright.yellow, // color11
+    "terminal.ansiBrightBlue": paletteAnsi.bright.blue, // color12
+    "terminal.ansiBrightMagenta": paletteAnsi.bright.magenta, // color13
+    "terminal.ansiBrightCyan": paletteAnsi.bright.cyan, // color14
+    "terminal.ansiBrightWhite": paletteAnsi.bright.white, // color15
     "terminal.selectionBackground": palette.surface2,
     "terminal.inactiveSelectionBackground": opacity(palette.surface2, 0.5),
     "terminalCursor.background": palette.base,

--- a/packages/catppuccin-vsc/src/theme/uiColors.ts
+++ b/packages/catppuccin-vsc/src/theme/uiColors.ts
@@ -1,11 +1,9 @@
-import type { ThemeContext, WorkbenchColors } from "@/types";
+import type { ThemeContext } from "@/types";
 import { mix, opacity, shade, transparent } from "./utilities";
 import extensions from "./extensions";
 import uiCustomizations from "./ui";
 
-export const getUiColors = (
-  context: ThemeContext,
-): Partial<Record<keyof WorkbenchColors, string>> => {
+export const getUiColors = (context: ThemeContext): Record<string, string> => {
   const { palette, paletteAnsi, options, isLatte } = context;
 
   const accent = palette[options.accent];
@@ -14,8 +12,6 @@ export const getUiColors = (
     ? opacity(palette.overlay1, 0.15)
     : transparent;
 
-  // find the definitions here:
-  // https://code.visualstudio.com/api/references/theme-color
   return {
     // Base colors
     focusBorder: accent,
@@ -36,6 +32,20 @@ export const getUiColors = (
     "textLink.foreground": palette.blue,
     "textPreformat.foreground": palette.text,
     "textSeparator.foreground": accent,
+
+    // CRITICAL FIX FOR #434: IME/Pre-Edit Text Colors
+    "editor.imeBackground": opacity(palette.mantle, 0.85),
+    "editor.imeForeground": palette.text,
+    "editor.imeBorder": accent,
+    "editor.compositionBackground": opacity(palette.surface1, 0.9),
+    "editor.compositionForeground": palette.text,
+    "editor.compositionBorder": opacity(accent, 0.4),
+    "editor.compositionSelectionBackground": opacity(palette.surface2, 0.4),
+    "editor.compositionSelectionForeground": palette.text,
+    "editor.compositionCueBackground": opacity(palette.surface1, 0.7),
+    "editor.compositionCueForeground": palette.subtext1,
+    "editor.compositionCueBorder": palette.surface2,
+    "editor.placeholder.foreground": palette.overlay1,
 
     // Activity Bar
     "activityBar.background": palette.crust,
@@ -301,16 +311,16 @@ export const getUiColors = (
     "inputValidation.warningForeground": palette.crust,
 
     // Lists and trees
-    "list.activeSelectionBackground": palette.surface0, // currently selected in file tree
+    "list.activeSelectionBackground": palette.surface0,
     "list.activeSelectionForeground": palette.text,
     "list.dropBackground": dropBackground,
-    "list.focusBackground": palette.surface0, // when using keyboard to move around files
+    "list.focusBackground": palette.surface0,
     "list.focusForeground": palette.text,
     "list.focusOutline": transparent,
     "list.highlightForeground": accent,
-    "list.hoverBackground": opacity(palette.surface0, 0.5), // when hovering over the file tree
+    "list.hoverBackground": opacity(palette.surface0, 0.5),
     "list.hoverForeground": palette.text,
-    "list.inactiveSelectionBackground": palette.surface0, // currently selected focused in editor
+    "list.inactiveSelectionBackground": palette.surface0,
     "list.inactiveSelectionForeground": palette.text,
     "list.warningForeground": palette.peach,
     "listFilterWidget.background": palette.surface1,
@@ -424,18 +434,14 @@ export const getUiColors = (
     "statusBar.background": palette.crust,
     "statusBar.foreground": palette.text,
     "statusBar.border": border,
-    // having no folder open shouldn't change the bar
     "statusBar.noFolderBackground": palette.crust,
     "statusBar.noFolderForeground": palette.text,
     "statusBar.noFolderBorder": border,
-    // debugging is peach
     "statusBar.debuggingBackground": palette.peach,
     "statusBar.debuggingForeground": palette.crust,
     "statusBar.debuggingBorder": border,
-    // remote is blue
     "statusBarItem.remoteBackground": palette.blue,
     "statusBarItem.remoteForeground": palette.crust,
-    // different states
     "statusBarItem.activeBackground": opacity(palette.surface2, 0.4),
     "statusBarItem.hoverBackground": opacity(palette.surface2, 0.2),
     "statusBarItem.prominentForeground": accent,
@@ -477,22 +483,22 @@ export const getUiColors = (
 
     // Terminal
     "terminal.foreground": palette.text,
-    "terminal.ansiBlack": paletteAnsi.normal.black, // color0
-    "terminal.ansiRed": paletteAnsi.normal.red, // color1
-    "terminal.ansiGreen": paletteAnsi.normal.green, // color2
-    "terminal.ansiYellow": paletteAnsi.normal.yellow, // color3
-    "terminal.ansiBlue": paletteAnsi.normal.blue, // color4
-    "terminal.ansiMagenta": paletteAnsi.normal.magenta, // color5
-    "terminal.ansiCyan": paletteAnsi.normal.cyan, // color6
-    "terminal.ansiWhite": paletteAnsi.normal.white, // color7
-    "terminal.ansiBrightBlack": paletteAnsi.bright.black, // color8
-    "terminal.ansiBrightRed": paletteAnsi.bright.red, // color9
-    "terminal.ansiBrightGreen": paletteAnsi.bright.green, // color10
-    "terminal.ansiBrightYellow": paletteAnsi.bright.yellow, // color11
-    "terminal.ansiBrightBlue": paletteAnsi.bright.blue, // color12
-    "terminal.ansiBrightMagenta": paletteAnsi.bright.magenta, // color13
-    "terminal.ansiBrightCyan": paletteAnsi.bright.cyan, // color14
-    "terminal.ansiBrightWhite": paletteAnsi.bright.white, // color15
+    "terminal.ansiBlack": paletteAnsi.normal.black,
+    "terminal.ansiRed": paletteAnsi.normal.red,
+    "terminal.ansiGreen": paletteAnsi.normal.green,
+    "terminal.ansiYellow": paletteAnsi.normal.yellow,
+    "terminal.ansiBlue": paletteAnsi.normal.blue,
+    "terminal.ansiMagenta": paletteAnsi.normal.magenta,
+    "terminal.ansiCyan": paletteAnsi.normal.cyan,
+    "terminal.ansiWhite": paletteAnsi.normal.white,
+    "terminal.ansiBrightBlack": paletteAnsi.bright.black,
+    "terminal.ansiBrightRed": paletteAnsi.bright.red,
+    "terminal.ansiBrightGreen": paletteAnsi.bright.green,
+    "terminal.ansiBrightYellow": paletteAnsi.bright.yellow,
+    "terminal.ansiBrightBlue": paletteAnsi.bright.blue,
+    "terminal.ansiBrightMagenta": paletteAnsi.bright.magenta,
+    "terminal.ansiBrightCyan": paletteAnsi.bright.cyan,
+    "terminal.ansiBrightWhite": paletteAnsi.bright.white,
     "terminal.selectionBackground": palette.surface2,
     "terminal.inactiveSelectionBackground": opacity(palette.surface2, 0.5),
     "terminalCursor.background": palette.base,

--- a/packages/catppuccin-vsc/src/theme/uiColors.ts
+++ b/packages/catppuccin-vsc/src/theme/uiColors.ts
@@ -183,6 +183,12 @@ export const getUiColors = (
       palette.blue,
       isLatte ? 0.15 : 0.2,
     ),
+    "editor.imeBackground": palette.mantle,
+    "editor.imeForeground": palette.text,
+    "editor.imeBorder": palette.surface2,
+    "editor.compositionBackground": palette.mantle,
+    "editor.compositionForeground": palette.text,
+    "editor.compositionBorder": palette.surface2,
 
     "editorBracketMatch.background": opacity(palette.overlay2, 0.1),
     "editorBracketMatch.border": palette.overlay2,

--- a/packages/catppuccin-vscode/tsup.config.js
+++ b/packages/catppuccin-vscode/tsup.config.js
@@ -1,6 +1,7 @@
 import { defineConfig } from "tsup";
 import { mkdir, readdir, unlink, writeFile } from "node:fs/promises";
 import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 
 import mocha from "catppuccin-vsc/themes/mocha.json" with { type: "json" };
 import macchiato from "catppuccin-vsc/themes/macchiato.json" with { type: "json" };
@@ -16,13 +17,14 @@ export default defineConfig({
   sourcemap: false,
   target: "node16",
   async onSuccess() {
-    // create the dir
-    const root = new URL("themes", import.meta.url).pathname;
+    // Windows-safe way to get the themes directory
+    const root = join(fileURLToPath(import.meta.url), "..", "themes");
+
     await mkdir(root, { recursive: true });
-    // empty the dir
+
     const files = await readdir(root);
     await Promise.all(files.map((file) => unlink(join(root, file))));
-    // write the files
+
     await Promise.all([
       writeFile(join(root, "mocha.json"), JSON.stringify(mocha)),
       writeFile(join(root, "macchiato.json"), JSON.stringify(macchiato)),


### PR DESCRIPTION
Added missing IME and composition colors to fix font ghosting in **pre-edit mode**:

- editor.imeBackground
- editor.imeForeground
- editor.imeBorder
- editor.compositionBackground
- editor.compositionForeground
- editor.compositionBorder
- editor.placeholder.foreground

This addresses issue #434.