### PR TITLE
fix: use raw.githubusercontent.com for extension schemas

### DIFF
--- a/packages/catppuccin-vsc/package.json
+++ b/packages/catppuccin-vsc/package.json
@@ -78,14 +78,14 @@
           "type": "object",
           "default": {},
           "markdownDescription": "Custom color overrides. Assign your own hex codes to palette colors. See [the docs](https://github.com/catppuccin/vscode#override-palette-colors) for reference.",
-          "$ref": "https://esm.sh/gh/catppuccin/vscode@catppuccin-vsc-v3.18.1/packages/catppuccin-vsc/schemas/colorOverrides.schema.json"
+          "$ref": "https://raw.githubusercontent.com/catppuccin/vscode/catppuccin-vsc-v3.18.1/packages/catppuccin-vsc/schemas/colorOverrides.schema.json"
         },
         "catppuccin.customUIColors": {
           "scope": "application",
           "type": "object",
           "default": {},
           "markdownDescription": "Customize UI colors. Map `workbench.colorCustomizations` to palette colors. See [the docs](https://github.com/catppuccin/vscode#use-palette-colors-on-workbench-elements-ui) for reference.",
-          "$ref": "https://esm.sh/gh/catppuccin/vscode@catppuccin-vsc-v3.18.1/packages/catppuccin-vsc/schemas/customUIColors.schema.json"
+          "$ref": "https://raw.githubusercontent.com/catppuccin/vscode/catppuccin-vsc-v3.18.1/packages/catppuccin-vsc/schemas/customUIColors.schema.json"
         },
         "catppuccin.accentColor": {
           "scope": "application",

--- a/packages/catppuccin-vsc/src/hooks/packageJson.ts
+++ b/packages/catppuccin-vsc/src/hooks/packageJson.ts
@@ -48,7 +48,7 @@ const configuration = (version: string) => {
         default: {},
         markdownDescription:
           "Custom color overrides. Assign your own hex codes to palette colors. See [the docs](https://github.com/catppuccin/vscode#override-palette-colors) for reference.",
-        $ref: `https://esm.sh/gh/catppuccin/vscode@catppuccin-vsc-v${version}/packages/catppuccin-vsc/schemas/colorOverrides.schema.json`,
+        $ref: `https://raw.githubusercontent.com/catppuccin/vscode/catppuccin-vsc-v${version}/packages/catppuccin-vsc/schemas/colorOverrides.schema.json`,
       },
       "catppuccin.customUIColors": {
         scope: "application",
@@ -56,7 +56,7 @@ const configuration = (version: string) => {
         default: {},
         markdownDescription:
           "Customize UI colors. Map `workbench.colorCustomizations` to palette colors. See [the docs](https://github.com/catppuccin/vscode#use-palette-colors-on-workbench-elements-ui) for reference.",
-        $ref: `https://esm.sh/gh/catppuccin/vscode@catppuccin-vsc-v${version}/packages/catppuccin-vsc/schemas/customUIColors.schema.json`,
+        $ref: `https://raw.githubusercontent.com/catppuccin/vscode/catppuccin-vsc-v${version}/packages/catppuccin-vsc/schemas/customUIColors.schema.json`,
       },
       "catppuccin.accentColor": {
         scope: "application",


### PR DESCRIPTION
Closes #632

This changes the schema URLs for `catppuccin.colorOverrides` and `catppuccin.customUIColors` from `esm.sh` to `raw.githubusercontent.com` since VS Code trusts `raw.githubusercontent.com` by default for schema downloads, this should avoid the warning currently shown in `settings.json`