### PR TITLE
fix(theme): support all TOML date and time variants

### DIFF
--- a/packages/catppuccin-vsc/src/theme/tokens/data.ts
+++ b/packages/catppuccin-vsc/src/theme/tokens/data.ts
@@ -47,8 +47,13 @@ const tokens = (context: ThemeContext): TextmateColors => {
       },
     },
     {
-      name: "TOML dates",
-      scope: "constant.other.time.datetime.offset.toml",
+      name: "TOML dates and times",
+      scope: [
+        "constant.other.time.datetime.offset.toml",
+        "constant.other.time.datetime.local.toml",
+        "constant.other.time.date.toml",
+        "constant.other.time.time.toml",
+      ],
       settings: {
         foreground: palette.pink,
       },


### PR DESCRIPTION
## Summary

Extend the existing TOML date highlighting rule to cover every date and time
variant emitted by Even Better TOML's TextMate grammar:

- Offset date-time
- Local date-time
- Local date
- Local time

All variants now use the existing Catppuccin `pink` palette color.

## Motivation

The theme previously targeted only
`constant.other.time.datetime.offset.toml`.

The other valid TOML date and time scopes fell back to the generic `source`
foreground color:

- `constant.other.time.datetime.local.toml`
- `constant.other.time.date.toml`
- `constant.other.time.time.toml`

## Testing

Tested using Catppuccin Mocha and Even Better TOML in the Extension Development
Host.

- Verified each scope with `Developer: Inspect Editor Tokens and Scopes`
- Confirmed all four variants use the existing TOML date color
- Ran `pnpm lint` successfully

## Screenshots

### Before

<img width="1961" height="716" alt="Screenshot From 2026-08-20 06-23-50" src="https://github.com/user-attachments/assets/6e665c85-42d6-409c-baf3-e47ffb42b383" />

### After

<img width="1961" height="716" alt="Screenshot From 2026-08-20 06-23-16" src="https://github.com/user-attachments/assets/09322914-7fb9-4ff8-a6f7-520bcb5c184c" />